### PR TITLE
Basic file filters (flavors)

### DIFF
--- a/src/zinc/__init__.py
+++ b/src/zinc/__init__.py
@@ -12,6 +12,7 @@ from .models import (ZincIndex, load_index, ZincError, ZincErrors,
         ZincOperation, ZincConfig, load_config, ZincManifest, load_manifest,
         CreateBundleVersionOperation, ZincCatalog, create_catalog_at_path)
 from .defaults import defaults
+from .pathfilter import PathFilter
 
 
 logging.basicConfig(level=logging.DEBUG,

--- a/src/zinc/models.py
+++ b/src/zinc/models.py
@@ -92,6 +92,7 @@ class ZincIndex(object):
         return self._get_or_create_bundle_info(bundle_name).get('versions')
 
     def delete_bundle_version(self, bundle_name, bundle_version):
+        assert bundle_version == int(bundle_version)
         bundle_info = self.bundle_info_by_name.get(bundle_name)
         if bundle_info is None:
             raise Exception("Unknown bundle %s" % (bundle_name))
@@ -106,6 +107,7 @@ class ZincIndex(object):
             del self.bundle_info_by_name[bundle_name]
         else:
             bundle_info['versions'] = versions
+
         
     def distributions_for_bundle(self, bundle_name):
         bundle_info = self.bundle_info_by_name.get(bundle_name)
@@ -450,6 +452,7 @@ class ZincCatalog(object):
 
     def clean(self, dry_run=False):
         bundle_descriptors = self.bundle_descriptors()
+        verb = 'Would remove' if dry_run else 'Removing'
 
         ### 1. scan manifests for ones that aren't in index
         for root, dirs, files in os.walk(self._manifests_dir()):
@@ -463,7 +466,7 @@ class ZincCatalog(object):
                     if bundle_descr not in bundle_descriptors:
                         remove = True
                 if remove:
-                    logging.info("Removing %s" % (pjoin(root, f)))
+                    logging.info("%s %s" % (verb, pjoin(root, f)))
                     if not dry_run: os.remove(pjoin(root, f))
 
         ### 2. scan archives for ones that aren't in index
@@ -478,7 +481,7 @@ class ZincCatalog(object):
                     if bundle_descr not in bundle_descriptors:
                         remove = True
                 if remove:
-                    logging.info("Removing %s" % (pjoin(root, f)))
+                    logging.info("%s %s" % (verb, pjoin(root, f)))
                     if not dry_run: os.remove(pjoin(root, f))
 
         ### 3. clean objects
@@ -491,7 +494,7 @@ class ZincCatalog(object):
             for f in files:
                 basename = os.path.splitext(f)[0]
                 if basename not in all_objects:
-                    logging.info("Removing %s" % (pjoin(root, f)))
+                    logging.info("%s %s" % (verb, pjoin(root, f)))
                     if not dry_run: os.remove(pjoin(root, f))
 
     def verify(self):

--- a/src/zinc/pathfilter.py
+++ b/src/zinc/pathfilter.py
@@ -6,25 +6,6 @@ class Match:
     REJECT=2
     UNKNOWN=3
 
-
-def path_filter_from_rule_list(rule_list):
-    """Read from a dict. `version` is ignored"""
-    rules = []
-    for rule_string in rule_list:
-        rule_string = rule_string.strip()
-        rule_comps = rule_string.split()
-        match_action_string = rule_comps[0]
-        if match_action_string == '+':
-            match_action = Match.ACCEPT
-        elif match_action_string == '-': 
-            match_action = Match.REJECT
-        else:
-            raise ValueError("unknown match type")
-        pattern = string.join(rule_comps[1:], ' ')
-        rules.append(PathFilter.Rule(pattern, match_action))
-    return PathFilter(rules)
-
-
 class PathFilter(object):
 
     class Rule(object):
@@ -50,4 +31,22 @@ class PathFilter(object):
                 return False
         return True
 
-
+    @staticmethod
+    def from_rule_list(rule_list):
+        """Read from a dict. `version` is ignored"""
+        rules = []
+        for rule_string in rule_list:
+            rule_string = rule_string.strip()
+            rule_comps = rule_string.split()
+            match_action_string = rule_comps[0]
+            if match_action_string == '+':
+                match_action = Match.ACCEPT
+            elif match_action_string == '-': 
+                match_action = Match.REJECT
+            else:
+                raise ValueError("unknown match type: %s" %
+                        (match_action_string))
+            pattern = string.join(rule_comps[1:], ' ')
+            rules.append(PathFilter.Rule(pattern, match_action))
+        return PathFilter(rules)
+    

--- a/src/zinc/pathfilter.py
+++ b/src/zinc/pathfilter.py
@@ -1,0 +1,33 @@
+import fnmatch
+
+class Match:
+    ACCEPT=1
+    REJECT=2
+    UNKNOWN=3
+
+class PathFilter(object):
+
+    class Rule(object):
+        def __init__(self, pattern, match_action):
+            assert match_action in (Match.ACCEPT, Match.REJECT)
+            self.pattern = pattern
+            self.match_action = match_action
+
+        def match(self, path):
+            if fnmatch.fnmatch(path, self.pattern):
+                return self.match_action
+            return Match.UNKNOWN
+
+    def __init__(self, rules):
+        self._rules = rules
+
+    def match(self, path):
+        """Tests the path against all rules in this filter"""
+        for rule in self._rules:
+            if rule.match(path) == Match.ACCEPT:
+                return True
+            elif rule.match(path) == Match.REJECT:
+                return False
+        return True
+
+

--- a/src/zinc/pathfilter.py
+++ b/src/zinc/pathfilter.py
@@ -1,9 +1,29 @@
 import fnmatch
+import string
 
 class Match:
     ACCEPT=1
     REJECT=2
     UNKNOWN=3
+
+
+def path_filter_from_rule_list(rule_list):
+    """Read from a dict. `version` is ignored"""
+    rules = []
+    for rule_string in rule_list:
+        rule_string = rule_string.strip()
+        rule_comps = rule_string.split()
+        match_action_string = rule_comps[0]
+        if match_action_string == '+':
+            match_action = Match.ACCEPT
+        elif match_action_string == '-': 
+            match_action = Match.REJECT
+        else:
+            raise ValueError("unknown match type")
+        pattern = string.join(rule_comps[1:], ' ')
+        rules.append(PathFilter.Rule(pattern, match_action))
+    return PathFilter(rules)
+
 
 class PathFilter(object):
 

--- a/tests/testPathFilter.py
+++ b/tests/testPathFilter.py
@@ -1,0 +1,62 @@
+from tests import *
+from zinc import *
+import os.path
+from zinc.pathfilter import Match
+
+class TestPathFilterRuleMatching(unittest.TestCase):
+
+    def test_no_match_accept(self):
+        r = PathFilter.Rule('a', Match.ACCEPT)
+        self.assertEquals(r.match('b'), Match.UNKNOWN)
+
+    def test_no_match_reject(self):
+        r = PathFilter.Rule('a', Match.REJECT)
+        self.assertEquals(r.match('b'), Match.UNKNOWN)
+
+    def test_exact_accept(self):
+        r = PathFilter.Rule('/path', Match.ACCEPT)
+        self.assertEquals(r.match('/path'), Match.ACCEPT)
+
+    def test_exact_reject(self):
+        r = PathFilter.Rule('/path', Match.REJECT)
+        self.assertEquals(r.match('/path'), Match.REJECT)
+
+    def test_end_of_path_match(self):
+        r = PathFilter.Rule('*/honk', Match.ACCEPT)
+        self.assertEquals(r.match('beep/honk'), Match.ACCEPT)
+
+    def test_middle_of_path_match(self):
+        r = PathFilter.Rule('*/honk/*', Match.ACCEPT)
+        self.assertEquals(r.match('/beep/honk/boop'), Match.ACCEPT)
+
+
+class TestPathFilterMatching(unittest.TestCase):
+
+    def test_empty(self):
+        pf = PathFilter([])
+        self.assertTrue(pf.match('/some/random/path'))
+
+    def test_accept_all_in_dir(self):
+        pf = PathFilter([
+            PathFilter.Rule('*/100/*', Match.ACCEPT),
+            PathFilter.Rule('*', Match.REJECT)])
+        self.assertTrue(pf.match('/this/is/valid/100/file.png'))
+        self.assertTrue(pf.match('/this/is/valid/100/file.jpg'))
+        self.assertFalse(pf.match('/this/is/not/valid/20/file.png'))
+
+    def test_accept_all_in_dir_with_exention(self):
+        pf = PathFilter([
+            PathFilter.Rule('*/100/*.png', Match.ACCEPT),
+            PathFilter.Rule('*', Match.REJECT)])
+        self.assertTrue(pf.match('/this/is/valid/100/file.png'))
+        self.assertFalse(pf.match('/this/is/not/valid/20/file.png'))
+        self.assertFalse(pf.match('/this/is/not/valid/100/file.jpg'))
+
+    def test_reject_all_in_dir(self):
+        pf = PathFilter([
+            PathFilter.Rule('*/100/*', Match.REJECT)])
+        self.assertFalse(pf.match('/this/is/valid/100/file.png'))
+        self.assertFalse(pf.match('/this/is/valid/100/file.jpg'))
+        self.assertTrue(pf.match('/this/is/not/valid/20/file.png'))
+
+

--- a/tests/testPathFilter.py
+++ b/tests/testPathFilter.py
@@ -1,7 +1,7 @@
 from tests import *
 from zinc import *
 import os.path
-from zinc.pathfilter import Match
+from zinc.pathfilter import Match, path_filter_from_rule_list
 
 class TestPathFilterRuleMatching(unittest.TestCase):
 
@@ -58,5 +58,14 @@ class TestPathFilterMatching(unittest.TestCase):
         self.assertFalse(pf.match('/this/is/valid/100/file.png'))
         self.assertFalse(pf.match('/this/is/valid/100/file.jpg'))
         self.assertTrue(pf.match('/this/is/not/valid/20/file.png'))
+
+    def test_read_json(self):
+        pf = path_filter_from_rule_list(['+ a'])
+        self.assertTrue(pf is not None)
+
+    def test_read_json_invalid(self):
+        self.assertRaises(Exception, path_filter_from_rule_list, ['? a'])
+
+
 
 

--- a/tests/testPathFilter.py
+++ b/tests/testPathFilter.py
@@ -1,7 +1,7 @@
 from tests import *
 from zinc import *
 import os.path
-from zinc.pathfilter import Match, path_filter_from_rule_list
+from zinc.pathfilter import Match
 
 class TestPathFilterRuleMatching(unittest.TestCase):
 
@@ -60,11 +60,11 @@ class TestPathFilterMatching(unittest.TestCase):
         self.assertTrue(pf.match('/this/is/not/valid/20/file.png'))
 
     def test_read_json(self):
-        pf = path_filter_from_rule_list(['+ a'])
+        pf = PathFilter.from_rule_list(['+ a'])
         self.assertTrue(pf is not None)
 
     def test_read_json_invalid(self):
-        self.assertRaises(Exception, path_filter_from_rule_list, ['? a'])
+        self.assertRaises(Exception, PathFilter.from_rule_list, ['? a'])
 
 
 

--- a/tests/testZincModels.py
+++ b/tests/testZincModels.py
@@ -129,13 +129,6 @@ class ZincCatalogTestCase(TempDirTestCase):
         filename = os.path.split(path)[-1]
         self.assertEquals(filename, 'zoo-1.json')
 
-    #def test_path_for_manifest_with_name_version_flavor(self):
-    #    catalog = self._build_test_catalog()
-    #    manifest = ZincManifest(catalog.index.id, 'zoo', 1, 'vanilla')
-    #    path = catalog._path_for_manifest(manifest)
-    #    filename = os.path.split(path)[-1]
-    #    self.assertEquals(filename, 'zoo-1~vanilla.json')
-
 class ZincIndexTestCase(TempDirTestCase):
 
     def test_versions_for_nonexistant_bundle(self):


### PR DESCRIPTION
This introduces a basic way to create different "flavors" of a bundle by filtering files. A different flavor of a bundle has the same contents conceptually, but files might be a different format. For example, you might create flavors for regular (non-retina) and retina (@2x) images.

To create a bundle with flavors, you must pass a flavorspec on the command line. _This is highly subject to change_. A flavorspec is a dictionary where the keys are the name of the flavor, and the value is a list of patterns.

```
{
    "small"  : ["+ */photos/85x85/*",
                "- */photos/*"],
    "medium" : ["+ */photos/170x170/*",
                "- */photos/*"],
    "large"  : ["+ */photos/340x340/*",
                "- */photos/*"]
}
```

The patterns are inspired by rsync's ignore/exclude format, but currently far less powerful. A single pattern looks like this

```
- */photos/*
```

All patterns must begin with a `+` (accept) or `-` (reject). Paths are tested against the list of patterns in order, until a match is found. If no match is found, accept is assumed.

Next save the flavorspec to a file, and update a bundle like this

```
zinc bundle:update -f myflavorspec.json bar path
```

This will create a bundle as normal (with all files), but it will add some additional information to the manifest, as well as create some new archives.

Manifests now contain a list of flavors at the top level:

```
{
  "bundle": "bar",
  "catalog": "com.foo",
  "flavors": [  
    "large",
    "small",
    "medium"
  ],
  "files": {
    "photos/340x340/three@2x~ipad.jpg": {
      "formats": {
        "gz": {
          "size": 72725
        }
      },
      "flavors": [
        "large"
      ],
      "sha": "7a0ec70c44168123afcde33502c5cdd78b4582a0"
    },
}
```

And in addition, every file entry now includes the flavors it belongs to (snippet from above):

```
"photos/340x340/three@2x~ipad.jpg": {
     "formats": {
       "gz": {
         "size": 72725
       }
     },
     "flavors": [
       "large"
     ],
     "sha": "7a0ec70c44168123afcde33502c5cdd78b4582a0"
   }
}
```

Finally, archives are created for each flavor `~<flavorname>` is appended to archive name:

```
com.foo.bar-1~small.tar
com.foo.bar-1~medium.tar
com.foo.bar-1~large.tar
```

This information will allow clients to download or bootstrap a particular flavor, which should reduce IO and processing time.

Clients can choose to ignore flavor information and just download the full archive or use all files in the manifest.
