### PR TITLE
[WIP] Added ability to list file sizes and limit output by flavor.

### DIFF
--- a/src/zinc/__init__.py
+++ b/src/zinc/__init__.py
@@ -59,6 +59,24 @@ def catalog_list(args):
         final_string =  "[%s]" %(", ".join(version_strings))
         print "%s %s" % (bundle_name, final_string)
 
+def catalog_size(args):
+    catalog = ZincCatalog(args.catalog_path)
+    size_sum = 0
+    for bundle_name in catalog.bundle_names():
+        version_for_distro = catalog.index.version_for_bundle(bundle_name, args.distribution)
+        
+        if version_for_distro is None:
+            print "Unable to find distribution: %s for bundle: %s" % (args.distribution, bundle_name)
+            break;
+
+        manifest = catalog.manifest_for_bundle(bundle_name, version=version_for_distro)
+        manifest_size = manifest.size(args.flavor)
+        size_sum += manifest_size
+        print "%s size: %s" % (bundle_name, human_readable_filesize(manifest_size))
+
+    print "Catalog size: %s" % human_readable_filesize(size_sum)
+
+
 def bundle_list(args):
     catalog = ZincCatalog(args.catalog_path)
     bundle_name = args.bundle_name
@@ -174,6 +192,17 @@ def main():
     parser_catalog_list.add_argument('-c', '--catalog_path', default='.',
             help='Catalog path. Defaults to "."')
     parser_catalog_list.set_defaults(func=catalog_list)
+
+    # catalog:size
+    parser_catalog_size = subparsers.add_parser('catalog:size',
+            help='List size of each bundle in specified catalog and total size of entire catalog.')
+    parser_catalog_size.add_argument('-c', '--catalog_path', default='.',
+            help='Catalog path. Defaults to "."')
+    parser_catalog_size.add_argument('--flavor',
+            help='Limits size calculation to files belonging to specified flavor.')
+    parser_catalog_size.add_argument('distribution',
+            help='Distribution.')
+    parser_catalog_size.set_defaults(func=catalog_size)
 
     # bundle:list
     parser_bundle_list = subparsers.add_parser('bundle:list', 

--- a/src/zinc/models.py
+++ b/src/zinc/models.py
@@ -221,6 +221,9 @@ class ZincManifest(object):
         props = self.files[path]
         formats = props.get('formats')
         return formats
+
+    def size_for_file(self, path):
+        return self.files.get(path).get('formats').itervalues().next().get('size')
         
     def add_flavor_for_file(self, path, flavor):
         props = self.files[path]

--- a/src/zinc/models.py
+++ b/src/zinc/models.py
@@ -224,6 +224,13 @@ class ZincManifest(object):
 
     def size_for_file(self, path):
         return self.files.get(path).get('formats').itervalues().next().get('size')
+
+    def size(self, flavor=None):
+        files = self.get_all_files(flavor)
+        size_sum = 0
+        for f in files:
+            size_sum += self.size_for_file(f)
+        return size_sum
         
     def add_flavor_for_file(self, path, flavor):
         props = self.files[path]
@@ -289,7 +296,6 @@ class ZincManifest(object):
                 and set(self.flavors) == set(other.flavors)
 
 def load_manifest(path):
-    print path
     manifest_file = open(path, 'r')
     dict = json.load(manifest_file)
     manifest_file.close()

--- a/src/zinc/utils.py
+++ b/src/zinc/utils.py
@@ -51,4 +51,10 @@ def gunzip(src_path, dst_path):
     f_out.close()
     f_in.close()
 
-
+def human_readable_filesize(num):
+    for x in ['bytes','KB','MB','GB']:
+        if num < 1024.0:
+            return "%3.1f%s" % (num, x)
+        num /= 1024.0
+    return "%3.1f%s" % (num, 'TB')
+    


### PR DESCRIPTION
This adds some new options to the bundle:list command:
- New `--size` argument outputs file sizes for each file (in bytes) along with the total size of the bundle.
- New `--human_size` argument outputs human readable file sizes for each file along with the total size of the bundle.
- New `--flavor` argument allows you to specify a flavor and limit output to files only belonging to that flavor.

**TODO:**
- Improve new `size_for_file` method. The code is quite messy and I need to determine what to do if there are both compressed and uncompressed versions of a file.
- Update tests.
