### PR TITLE
Storing "next_version" for each bundle

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open(os.path.join(here, 'README.rst')).read()
 NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 
 
-version = '0.1.3'
+version = '0.1.4'
 
 install_requires = [
     # List your project dependencies here.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open(os.path.join(here, 'README.rst')).read()
 NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 
 
-version = '0.1.4'
+version = '0.1.5'
 
 install_requires = [
     # List your project dependencies here.

--- a/src/zinc/models.py
+++ b/src/zinc/models.py
@@ -331,12 +331,6 @@ class CreateBundleVersionOperation(ZincOperation):
         self.flavor_spec = flavor_spec
         self.force = force
 
-#    def _next_version_for_bundle(self, bundle_id):
-#        versions = self.catalog.versions_for_bundle(bundle_id)
-#        if len(versions) == 0:
-#            return 1
-#        return versions[-1] + 1
-#
     def _generate_manifest(self, version, flavor_spec=None):
         """Create a new temporary manifest."""
         new_manifest = ZincManifest(

--- a/src/zinc/models.py
+++ b/src/zinc/models.py
@@ -99,18 +99,38 @@ class ZincIndex(object):
             self.bundle_info_by_name[bundle_name] = {
                     'versions':[],
                     'distributions':{},
+                    'next_version':1,
                     }
         return self.bundle_info_by_name.get(bundle_name)
 
     def add_version_for_bundle(self, bundle_name, version):
         bundle_info = self._get_or_create_bundle_info(bundle_name)
         if version not in bundle_info['versions']:
+            next_version = self.next_version_for_bundle(bundle_name) 
+            if version != next_version:
+                raise Exception("Expected next bundle version %d, got version %d" 
+                        % (verison, next_version))
             bundle_info['versions'].append(version)
             bundle_info['versions'] = sorted(bundle_info['versions'])
+            bundle_info['next_version'] = version + 1
 
     def versions_for_bundle(self, bundle_name):
         return self._get_or_create_bundle_info(bundle_name).get('versions')
 
+    def next_version_for_bundle(self, bundle_name):
+        bundle_info = self._get_or_create_bundle_info(bundle_name)
+
+        next_version = bundle_info.get('next_version')
+        if next_version is None: # older index without next_version
+            versions = self.versions_for_bundle(bundle_name)
+            if len(versions) == 0:
+                next_version = 1
+            else: 
+                next_version = versions[-1] + 1
+            bundle_info['next-version'] = next_version
+
+        return next_version
+       
     def delete_bundle_version(self, bundle_name, bundle_version):
         assert bundle_version == int(bundle_version)
         bundle_info = self.bundle_info_by_name.get(bundle_name)
@@ -311,12 +331,12 @@ class CreateBundleVersionOperation(ZincOperation):
         self.flavor_spec = flavor_spec
         self.force = force
 
-    def _next_version_for_bundle(self, bundle_id):
-        versions = self.catalog.versions_for_bundle(bundle_id)
-        if len(versions) == 0:
-            return 1
-        return versions[-1] + 1
-
+#    def _next_version_for_bundle(self, bundle_id):
+#        versions = self.catalog.versions_for_bundle(bundle_id)
+#        if len(versions) == 0:
+#            return 1
+#        return versions[-1] + 1
+#
     def _generate_manifest(self, version, flavor_spec=None):
         """Create a new temporary manifest."""
         new_manifest = ZincManifest(
@@ -380,7 +400,7 @@ class CreateBundleVersionOperation(ZincOperation):
                 v.close()
 
     def run(self):
-        version = self._next_version_for_bundle(self.bundle_id)
+        version = self.catalog.index.next_version_for_bundle(self.bundle_id)
 
         manifest = self.catalog.manifest_for_bundle(self.bundle_id)
         new_manifest = self._generate_manifest(version)

--- a/tests/testZincModels.py
+++ b/tests/testZincModels.py
@@ -144,6 +144,30 @@ class ZincCatalogTestCase(TempDirTestCase):
         archive_path = catalog._path_for_archive_for_bundle_version("meep", 1)
         self.assertTrue(os.path.exists(archive_path))
 
+    def test_next_version_is_2_for_new_bundle(self):
+        catalog = create_catalog_at_path(self.catalog_dir, 'com.mindsnacks.test')
+        f1 = create_random_file(self.scratch_dir)
+        catalog.create_bundle_version("meep", self.scratch_dir)
+        next_version = catalog.index.next_version_for_bundle("meep")
+        self.assertEquals(next_version, 2)
+
+    def test_next_version_is_added_if_missing(self):
+        catalog = create_catalog_at_path(self.catalog_dir, 'com.mindsnacks.test')
+       
+        # create v1
+        f1 = create_random_file(self.scratch_dir)
+        catalog.create_bundle_version("meep", self.scratch_dir)
+        
+        # remove the 'next_version' key
+        del catalog.index.bundle_info_by_name["meep"]["next_version"]
+       
+        # create v2
+        f2 = create_random_file(self.scratch_dir)
+        catalog.create_bundle_version("meep", self.scratch_dir)
+
+        # check
+        next_version = catalog.index.next_version_for_bundle("meep")
+        self.assertEquals(next_version, 3)
 
 
 class ZincIndexTestCase(TempDirTestCase):


### PR DESCRIPTION
This is necessary to properly support deletion.

Scenario:
- create new version 5 (latest)
- deploy new version 5
- delete version 5
- create a new version again

The steps above would lead to the second new version being 5, next_version was based on the max current version +1. However, this means that there are 2 different version 5s that existed, which may break zinc integrity.
