### PR TITLE
[Idea] Add an API version header to all responses

### DIFF
--- a/src/metazinc/metazinc.py
+++ b/src/metazinc/metazinc.py
@@ -11,6 +11,7 @@ from flask import Flask, request, redirect, abort
 from config import ZINC_CONFIG
 
 REDIS = Redis.from_url(os.environ.get('REDISTOGO_URL', 'redis://localhost:6379'))
+API_VERSION = '1.0'
 
 def catalog_index_url(catalog):
 	return ZINC_CONFIG["url"] + '/' + catalog + '/index.json'
@@ -39,6 +40,7 @@ def file_path(manifest, path):
 
 def format_from_info(file_info):
 	return file_info.get('formats').items()[0][0]
+
 def file_extension(file_info):
 	format = format_from_info(file_info)
 	return ('.' + format if format != 'raw' else '')
@@ -90,6 +92,12 @@ Q = Queue(connection=REDIS)
 Jobs = {}
 
 app = Flask(__name__)
+
+@app.after_request
+def after_request(response):
+    response.headers.add('X-Zinc-API-Version', API_VERSION)
+    return response
+
 @app.route('/')
 def root():
     return 'Metazinc!'


### PR DESCRIPTION
This small change adds an `X-Zinc-API-Version` header to all responses. The reasoning is that it would allow end users to specify a catalog reference like

```
zinc+http://127.0.0.1:5000/com.mindsnacks.games
```

The zinc client would interpret the 'zinc+http' portion as a zinc REST API. The client could then do a HEAD request and determine the exact API version charge onward.
