### PR TITLE
Basic support for loading catalog with custom coordinator and storage backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+# Rope
+.ropeproject

--- a/src/zinc/__init__.py
+++ b/src/zinc/__init__.py
@@ -4,8 +4,7 @@ from .helpers import *
 from .defaults import defaults
 
 import logging
-logging.basicConfig(level=logging.DEBUG,
-        format='%(asctime)s %(levelname)s %(message)s')
+log = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     import zinc.cli

--- a/src/zinc/__init__.py
+++ b/src/zinc/__init__.py
@@ -3,8 +3,16 @@ from .errors import ZincErrors
 from .helpers import *
 from .defaults import defaults
 
+# Set default logging handler to avoid "No handler found" warnings.
 import logging
-log = logging.getLogger(__name__)
+try:  # Python 2.7+
+    from logging import NullHandler
+except ImportError:
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
+
+logging.getLogger(__name__).addHandler(NullHandler())
 
 if __name__ == "__main__":
     import zinc.cli

--- a/src/zinc/cli.py
+++ b/src/zinc/cli.py
@@ -1,7 +1,9 @@
 import argparse
 import os
 import json
+import logging
 
+import zinc
 from zinc.utils import *
 from zinc.client import *
 from zinc.tasks.bundle_clone import ZincBundleCloneTask
@@ -26,6 +28,18 @@ def load_config(path):
         sys.exit("File not found: %s" % (path))
 
     return ZincClientConfig.from_path(path)
+
+
+def set_loglevel(args):
+    # TODO: this could be a lot cleaner
+
+    if args.loglevel == 'info':
+        logging.basicConfig(level=logging.INFO)
+    elif args.loglevel == 'debug':
+        logging.basicConfig(level=logging.DEBUG,
+                            format='%(asctime)s %(levelname)s [%(name)s] %(message)s')
+    else:
+        logging.basicConfig(level=logging.ERROR)
 
 
 def catalog_from_config(config, catalog_ref):
@@ -236,6 +250,11 @@ def main():
     parser.add_argument('-C', '--config', default=DEFAULT_CONFIG_PATH,
             help='Config file path. Defaults to \'%s\'.' % (DEFAULT_CONFIG_PATH))
 
+    # TODO: embetter this
+    parser.add_argument('--loglevel', default='error',
+                        choices=('error', 'info', 'debug'),
+                        help='Log level.')
+
     subparsers = parser.add_subparsers(
             title='subcommands',
             description='valid subcommands',
@@ -350,6 +369,7 @@ def main():
 
     args = parser.parse_args()
     config = load_config(args.config)
+    set_loglevel(args)
     args.func(config, args)
 
 if __name__ == "__main__":

--- a/src/zinc/cli.py
+++ b/src/zinc/cli.py
@@ -68,7 +68,7 @@ def catalog_list(catalog, distro=None, print_versions=True):
                 version_string += '=' + distro_string
             version_strings.append(version_string)
 
-        final_version_string = "[%s]" %(", ".join(version_strings))
+        final_version_string = "[%s]" % (", ".join(version_strings))
         if print_versions:
             print "%s %s" % (bundle_name, final_version_string)
         else:

--- a/src/zinc/cli.py
+++ b/src/zinc/cli.py
@@ -1,9 +1,7 @@
 import argparse
 import os
 import json
-from os.path import join as pjoin
 
-from zinc import *
 from zinc.utils import *
 from zinc.client import *
 from zinc.tasks.bundle_clone import ZincBundleCloneTask

--- a/src/zinc/cli.py
+++ b/src/zinc/cli.py
@@ -30,6 +30,14 @@ def load_config(path):
     return ZincClientConfig.from_path(path)
 
 
+def catalog_from_config(config, catalog_ref):
+
+    if config.bookmarks.get(catalog_ref):
+        catalog_id = config.bookmarks[catalog_ref]['catalog_id']
+        service_info = config.services[config.bookmarks[catalog_ref]['service']]
+        return catalog_id, service_info
+
+
 ### Client Commands #################################################################
 # TODO: move to zinc.client ?
 
@@ -83,9 +91,15 @@ def distro_delete(catalog, distro_name, bundle_name):
 ### Subcommand Parsing #################################################################
 
 def subcmd_catalog_list(args, config):
-    r = catalog_ref_split(args.catalog)
-    service = connect(r.service)
-    catalog = service.get_catalog(**r.catalog._asdict())
+    catalog_id, service_info = catalog_from_config(config, args.catalog)
+    if service_info is not None:
+        service = connect(**service_info)
+        catalog = service.get_catalog(id=catalog_id)
+    else:
+        r = catalog_ref_split(args.catalog)
+        service = connect(r.service)
+        catalog = service.get_catalog(**r.catalog._asdict())
+
     distro = args.distro
     catalog_list(catalog, distro=distro, print_versions=not args.no_versions)
 

--- a/src/zinc/cli.py
+++ b/src/zinc/cli.py
@@ -48,14 +48,15 @@ def catalog_from_config(config, catalog_ref):
 
     if config.bookmarks.get(catalog_ref):
         catalog_id = config.bookmarks[catalog_ref]['catalog_id']
-        service_info = config.services[config.bookmarks[catalog_ref]['service']]
-        return catalog_id, service_info
+        coordinator_info = config.coordinators[config.bookmarks[catalog_ref]['coordinator']]
+        storage_info = config.storages[config.bookmarks[catalog_ref]['storage']]
+        return catalog_id, coordinator_info, storage_info
 
 
 def get_catalog(config, args):
-    catalog_id, service_info = catalog_from_config(config, args.catalog)
-    if service_info is not None:
-        service = connect(**service_info)
+    catalog_id, coordinator_info, storage_info = catalog_from_config(config, args.catalog)
+    if coordinator_info is not None and storage_info is not None:
+        service = connect(coordinator_info=coordinator_info, storage_info=storage_info)
         catalog = service.get_catalog(id=catalog_id)
     else:
         r = catalog_ref_split(args.catalog)

--- a/src/zinc/cli.py
+++ b/src/zinc/cli.py
@@ -195,9 +195,7 @@ def subcmd_distro_update(args, config):
 
 
 def subcmd_distro_delete(args, config):
-    r = catalog_ref_split(args.catalog)
-    service = connect(r.service)
-    catalog = service.get_catalog(**r.catalog._asdict())
+    catalog = get_catalog(args, config)
     bundle_name = args.bundle
     distro_name = args.distro
     distro_delete(catalog, distro_name, bundle_name)

--- a/src/zinc/cli.py
+++ b/src/zinc/cli.py
@@ -90,7 +90,7 @@ def distro_delete(catalog, distro_name, bundle_name):
 
 ### Subcommand Parsing #################################################################
 
-def subcmd_catalog_list(args, config):
+def get_catalog(args, config):
     catalog_id, service_info = catalog_from_config(config, args.catalog)
     if service_info is not None:
         service = connect(**service_info)
@@ -99,7 +99,11 @@ def subcmd_catalog_list(args, config):
         r = catalog_ref_split(args.catalog)
         service = connect(r.service)
         catalog = service.get_catalog(**r.catalog._asdict())
+    return catalog
 
+
+def subcmd_catalog_list(args, config):
+    catalog = get_catalog(args, config)
     distro = args.distro
     catalog_list(catalog, distro=distro, print_versions=not args.no_versions)
 
@@ -117,9 +121,7 @@ def cmd_catalog_clean(args, config):
 
 
 def subcmd_bundle_list(args, config):
-    r = catalog_ref_split(args.catalog)
-    service = connect(r.service)
-    catalog = service.get_catalog(**r.catalog._asdict())
+    catalog = get_catalog(args, config)
     bundle_name = args.bundle
     version = int(args.version)
     print_sha = args.sha

--- a/src/zinc/cli.py
+++ b/src/zinc/cli.py
@@ -8,7 +8,7 @@ from zinc.utils import *
 from zinc.client import *
 from zinc.tasks.bundle_clone import ZincBundleCloneTask
 
-DEFAULT_CONFIG_PATH='~/.zinc'
+DEFAULT_CONFIG_PATH = '~/.zinc'
 
 
 ### Helpers ##################################################################
@@ -48,11 +48,12 @@ def catalog_list(catalog, distro=None, print_versions=True):
                 version_string += '=' + distro_string
             version_strings.append(version_string)
 
-        final_version_string =  "[%s]" %(", ".join(version_strings))
+        final_version_string = "[%s]" %(", ".join(version_strings))
         if print_versions:
             print "%s %s" % (bundle_name, final_version_string)
         else:
             print "%s" % (bundle_name)
+
 
 def bundle_list(catalog, bundle_name, version, print_sha=False):
     manifest = catalog.manifest_for_bundle(bundle_name, version=version)
@@ -63,6 +64,7 @@ def bundle_list(catalog, bundle_name, version, print_sha=False):
         else:
             print f
 
+
 def distro_update(catalog, bundle_name, distro_name, version_name):
     if version_name == "latest":
         bundle_version = catalog.versions_for_bundle(bundle_name)[-1]
@@ -71,8 +73,8 @@ def distro_update(catalog, bundle_name, distro_name, version_name):
         bundle_version = catalog.index.version_for_bundle(bundle_name, source_distro)
     else:
         bundle_version = int(version_name)
-    catalog.update_distribution(
-            distro_name, bundle_name, bundle_version)
+    catalog.update_distribution(distro_name, bundle_name, bundle_version)
+
 
 def distro_delete(catalog, distro_name, bundle_name):
     catalog.delete_distribution(distro_name, bundle_name)
@@ -85,14 +87,15 @@ def subcmd_catalog_list(args, config):
     service = connect(r.service)
     catalog = service.get_catalog(**r.catalog._asdict())
     distro = args.distro
-    catalog_list(catalog, distro=distro, 
-            print_versions=not args.no_versions)
- 
+    catalog_list(catalog, distro=distro, print_versions=not args.no_versions)
+
+
 def cmd_catalog_create(args, config):
     dest = args.catalog
     if dest is None:
         dest = './%s' % (args.catalog_id)
     create_catalog_at_path(dest, args.catalog_id)
+
 
 def cmd_catalog_clean(args, config):
     catalog = ZincCatalog(args.catalog)
@@ -108,6 +111,7 @@ def subcmd_bundle_list(args, config):
     print_sha = args.sha
     bundle_list(catalog, bundle_name, version, print_sha=print_sha)
 
+
 def cmd_bundle_update(args, config):
     flavors = None
     if args.flavors is not None:
@@ -122,10 +126,11 @@ def cmd_bundle_update(args, config):
     path = args.path
     force = args.force
     skip_master_archive = args.skip_master_archive
-    manifest = create_bundle_version(catalog,
-            bundle_name, path, flavor_spec=flavors, force=force,
-            skip_master_archive=skip_master_archive)
+    manifest = create_bundle_version(catalog, bundle_name, path,
+                                     flavor_spec=flavors, force=force,
+                                     skip_master_archive=skip_master_archive)
     print "Updated %s v%d" % (manifest.bundle_name, manifest.version)
+
 
 def cmd_bundle_clone(args, config):
 
@@ -138,6 +143,7 @@ def cmd_bundle_clone(args, config):
     task.output_path = args.path
 
     task.run()
+
 
 def cmd_bundle_delete(args, confg):
     bundle_name = args.bundle
@@ -163,6 +169,7 @@ def cmd_bundle_delete(args, confg):
         for v in versions_to_delete:
             catalog.delete_bundle_version(bundle_name, int(v))
 
+
 def subcmd_distro_update(args, config):
     r = catalog_ref_split(args.catalog)
     service = connect(r.service)
@@ -171,6 +178,7 @@ def subcmd_distro_update(args, config):
     distro_name = args.distro
     version_name = args.version
     distro_update(catalog, bundle_name, distro_name, version_name)
+
 
 def subcmd_distro_delete(args, config):
     r = catalog_ref_split(args.catalog)
@@ -228,7 +236,7 @@ def main():
             'catalog:clean', help='catalog:clean help')
     add_catalog_arg(parser_catalog_clean)
     parser_catalog_clean.add_argument(
-            '-f', '--force', default=False, action='store_true', 
+            '-f', '--force', default=False, action='store_true',
             help='This command does a dry run by default. Specifying this flag '
             'will cause files to actually be removed.')
     parser_catalog_clean.set_defaults(func=cmd_catalog_clean)
@@ -239,7 +247,7 @@ def main():
     add_catalog_arg(parser_catalog_list)
     add_distro_arg(parser_catalog_list, required=False)
     parser_catalog_list.add_argument(
-            '--no-versions', default=False, action='store_true', 
+            '--no-versions', default=False, action='store_true',
             help='Omit version information for bundles.')
     parser_catalog_list.set_defaults(func=subcmd_catalog_list)
 
@@ -250,7 +258,7 @@ def main():
     add_bundle_arg(parser_bundle_list)
     add_version_arg(parser_bundle_list)
     parser_bundle_list.add_argument(
-            '--sha', default=False, action='store_true', 
+            '--sha', default=False, action='store_true',
             help='Print file SHA hash.')
     parser_bundle_list.set_defaults(func=subcmd_bundle_list)
 
@@ -265,10 +273,10 @@ def main():
     parser_bundle_update.add_argument(
             '--flavors', help='Flavor spec path. Should be JSON.')
     parser_bundle_update.add_argument(
-            '--skip-master-archive', default=False, action='store_true', 
+            '--skip-master-archive', default=False, action='store_true',
             help='Skips creating master archive if flavors are specified.')
     parser_bundle_update.add_argument(
-            '-f', '--force', default=False, action='store_true', 
+            '-f', '--force', default=False, action='store_true',
             help='Update bundle even if no files changed.')
     parser_bundle_update.set_defaults(func=cmd_bundle_update)
 
@@ -292,7 +300,7 @@ def main():
     add_bundle_arg(parser_bundle_delete)
     add_version_arg(parser_bundle_delete)
     parser_bundle_delete.add_argument(
-            '-n', '--dry-run', default=False, action='store_true', 
+            '-n', '--dry-run', default=False, action='store_true',
             help='Dry run. Don\' actually delete anything.')
     parser_bundle_delete.set_defaults(func=cmd_bundle_delete)
 

--- a/src/zinc/cli.py
+++ b/src/zinc/cli.py
@@ -187,9 +187,7 @@ def cmd_bundle_delete(args, confg):
 
 
 def subcmd_distro_update(args, config):
-    r = catalog_ref_split(args.catalog)
-    service = connect(r.service)
-    catalog = service.get_catalog(**r.catalog._asdict())
+    catalog = get_catalog(args, config)
     bundle_name = args.bundle
     distro_name = args.distro
     version_name = args.version

--- a/src/zinc/cli.py
+++ b/src/zinc/cli.py
@@ -327,4 +327,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/src/zinc/cli.py
+++ b/src/zinc/cli.py
@@ -3,7 +3,6 @@ import os
 import json
 import logging
 
-import zinc
 from zinc.utils import *
 from zinc.client import *
 from zinc.tasks.bundle_clone import ZincBundleCloneTask

--- a/src/zinc/cli.py
+++ b/src/zinc/cli.py
@@ -1,9 +1,12 @@
 import argparse
-import os
 import json
+import os
+import sys
 
-from zinc.utils import *
-from zinc.client import *
+from zinc.utils import canonical_path
+from zinc.client import (connect, catalog_ref_split, create_bundle_version,
+        ZincClientConfig)
+from zinc.models import ZincFlavorSpec
 from zinc.tasks.bundle_clone import ZincBundleCloneTask
 
 DEFAULT_CONFIG_PATH = '~/.zinc'

--- a/src/zinc/client.py
+++ b/src/zinc/client.py
@@ -1,8 +1,8 @@
 import toml
-import logging
 from urlparse import urlparse
 from collections import namedtuple
 
+import zinc
 from zinc.defaults import defaults
 from zinc.utils import *
 from zinc.helpers import *
@@ -94,7 +94,7 @@ def _catalog_connection_get_http(url):
     if api_version not in ZINC_SUPPORTED_API_VERSIONS:
         raise Exception("Unsupported Zinc API version '%s'" % (api_version))
     else:
-        logging.debug("Found Zinc API %s" % (api_version))
+        zinc.log.debug("Found Zinc API %s" % (api_version))
 
 
 def catalog_ref_split(catalog_ref):

--- a/src/zinc/client.py
+++ b/src/zinc/client.py
@@ -28,7 +28,7 @@ class ZincClientConfig(ZincModel):
 
     @classmethod
     def from_dict(cls, d, mutable=True):
-        replaced = cls._replace_vars(d, d[cls.VARS])
+        replaced = cls._replace_vars(d, d.get(cls.VARS))
         zincConfig = cls(replaced, mutable=mutable)
         return zincConfig
 

--- a/src/zinc/client.py
+++ b/src/zinc/client.py
@@ -1,15 +1,16 @@
 import toml
 from urlparse import urlparse
 from collections import namedtuple
+import logging
 
-import zinc
-from zinc.defaults import defaults
 from zinc.utils import *
 from zinc.helpers import *
 from zinc.models import ZincModel
 from zinc.tasks.bundle_update import ZincBundleUpdateTask
 from zinc.coordinators import coordinator_for_url
 from zinc.storages import storage_for_url
+
+log = logging.getLogger(__name__)
 
 
 class ZincClientConfig(ZincModel):
@@ -94,7 +95,7 @@ def _catalog_connection_get_http(url):
     if api_version not in ZINC_SUPPORTED_API_VERSIONS:
         raise Exception("Unsupported Zinc API version '%s'" % (api_version))
     else:
-        zinc.log.debug("Found Zinc API %s" % (api_version))
+        log.debug("Found Zinc API %s" % (api_version))
 
 
 def catalog_ref_split(catalog_ref):

--- a/src/zinc/client.py
+++ b/src/zinc/client.py
@@ -68,6 +68,7 @@ def create_bundle_version(catalog, bundle_name, src_dir, flavor_spec=None,
 
 ################################################################################
 
+
 def _catalog_connection_get_api_version(url):
     import requests
     ZINC_VERSION_HEADER = 'x-zinc-api-version'
@@ -78,6 +79,7 @@ def _catalog_connection_get_api_version(url):
         raise Exception("Unknown Zinc API - '%s' header not found" %
                 (ZINC_VERSION_HEADER))
     return api_version
+
 
 def _catalog_connection_get_http(url):
     ZINC_SUPPORTED_API_VERSIONS = ('1.0')
@@ -96,7 +98,7 @@ def catalog_ref_split(catalog_ref):
 
     urlcomps = urlparse(catalog_ref)
     if urlcomps.scheme in ('http', 'https'):
-        catalog_id  = os.path.split(urlcomps.path)[-1]
+        catalog_id = os.path.split(urlcomps.path)[-1]
         service = catalog_ref[:-len(catalog_id)]
         return CatalogRefSplitResult(service, CatalogInfo(catalog_id, None))
 

--- a/src/zinc/coordinators/__init__.py
+++ b/src/zinc/coordinators/__init__.py
@@ -1,22 +1,36 @@
 
-################################################################################
 
 class CatalogCoordinator(object):
 
-    def __init__(self, url=None):
+    def __init__(self, url=None, **kwargs):
         if url is not None:
-            assert self.validate_url(url)
+            assert self.valid_url(url)
             self._url = url
         else:
             self._url = None
+
+    @classmethod
+    def valid_url(cls, url):
+        raise NotImplementedError()
 
     @property
     def url(self):
         return self._url
 
-    def validate_url(self, url):
-        raise NotImplementedError()
-
     def get_index_lock(self, prefix=None):
         raise NotImplementedError()
 
+
+################################################################################
+
+
+def coordinator_for_url(url):
+    # TODO: better way to search for coordinators
+    from .filesystem import FilesystemCatalogCoordinator
+    from .redis import RedisCatalogCoordinator
+
+    coord_classes = (FilesystemCatalogCoordinator, RedisCatalogCoordinator)
+
+    for coord_class in coord_classes:
+        if coord_class.valid_url(url):
+            return coord_class

--- a/src/zinc/coordinators/filesystem.py
+++ b/src/zinc/coordinators/filesystem.py
@@ -5,6 +5,7 @@ from lockfile import FileLock
 from . import CatalogCoordinator
 from zinc.utils import *
 
+
 class FilesystemCatalogCoordinator(CatalogCoordinator):
 
     def _index_lock_path(self):

--- a/src/zinc/coordinators/filesystem.py
+++ b/src/zinc/coordinators/filesystem.py
@@ -20,7 +20,6 @@ class FilesystemCatalogCoordinator(CatalogCoordinator):
         return urlparse(self.url).path
 
     @classmethod
-    def validate_url(cls, url):
+    def valid_url(cls, url):
         urlcomps = urlparse(url)
         return urlcomps.scheme == 'file'
-

--- a/src/zinc/coordinators/redis.py
+++ b/src/zinc/coordinators/redis.py
@@ -38,7 +38,7 @@ class Lock(object):
         if not redis:
             redis = Redis()
         self.redis = redis
-        self.token = str(time.time()*random.random())
+        self.token = str(time.time() * random.random())
 
     def __enter__(self):
         redis = self.redis
@@ -65,10 +65,12 @@ class Lock(object):
 
 ################################################################################
 
+
 class LockException(Exception):
     pass
 
 ################################################################################
+
 
 class RedisCatalogCoordinator(CatalogCoordinator):
 
@@ -83,9 +85,10 @@ class RedisCatalogCoordinator(CatalogCoordinator):
 
     def get_index_lock(self, prefix=None):
         name = 'index'
-        if prefix: name = '%s.%s' % (prefix, name)
+        if prefix:
+            name = '%s.%s' % (prefix, name)
         return Lock(name, redis=self._redis)
-    
+
     @classmethod
     def validate_url(cls, url):
         return urlparse(url).scheme in ('redis')

--- a/src/zinc/coordinators/redis.py
+++ b/src/zinc/coordinators/redis.py
@@ -74,14 +74,14 @@ class LockException(Exception):
 
 class RedisCatalogCoordinator(CatalogCoordinator):
 
-    def __init__(self, redis=None, **kwargs):
+    def __init__(self, redis=None, redis_password=None, **kwargs):
         super(RedisCatalogCoordinator, self).__init__(**kwargs)
         assert self.url or redis
         if redis is not None:
             self._redis = redis
         else:
             u = urlparse(self.url)
-            self._redis = Redis(host=u.hostname, port=u.port)
+            self._redis = Redis(host=u.hostname, port=u.port, password=redis_password)
 
     def get_index_lock(self, prefix=None):
         name = 'index'

--- a/src/zinc/coordinators/redis.py
+++ b/src/zinc/coordinators/redis.py
@@ -90,6 +90,5 @@ class RedisCatalogCoordinator(CatalogCoordinator):
         return Lock(name, redis=self._redis)
 
     @classmethod
-    def validate_url(cls, url):
+    def valid_url(cls, url):
         return urlparse(url).scheme in ('redis')
-

--- a/src/zinc/defaults.py
+++ b/src/zinc/defaults.py
@@ -8,10 +8,12 @@ This module provides the Zinc configuration defaults.
 
 """
 
+from .formats import Formats
+
 defaults = dict()
 defaults['zinc_format'] = '1'
 defaults['catalog_index_name'] = 'index.json'
 defaults['catalog_config_name'] = 'config.json'
-defaults['catalog_preferred_formats'] = ['gz', 'raw']
+defaults['catalog_preferred_formats'] = [Formats.GZ, Formats.RAW]
 defaults['catalog_valid_formats'] = defaults['catalog_preferred_formats']
 defaults['catalog_lock_timeout'] = 60

--- a/src/zinc/formats.py
+++ b/src/zinc/formats.py
@@ -1,0 +1,4 @@
+
+from .utils import enum
+
+Formats = enum(RAW='raw', GZ='gz')

--- a/src/zinc/helpers.py
+++ b/src/zinc/helpers.py
@@ -1,17 +1,23 @@
 
 ### Utils
 
+from .formats import Formats
+
+
 def make_bundle_id(catalog_id, bundle_name):
     assert catalog_id
     assert bundle_name
     return '%s.%s' % (catalog_id, bundle_name)
 
+
 def make_bundle_descriptor(bundle_id, version, flavor=None):
     assert bundle_id
     assert version
     descriptor = '%s-%d' % (bundle_id, version)
-    if flavor is not None: descriptor += '~%s' % (flavor)
+    if flavor is not None:
+        descriptor += '~%s' % (flavor)
     return descriptor
+
 
 def _bundle_descriptor_without_flavor(bundle_descriptor):
     index = bundle_descriptor.rfind('~')
@@ -20,9 +26,11 @@ def _bundle_descriptor_without_flavor(bundle_descriptor):
     else:
         return bundle_descriptor[:index]
 
+
 def bundle_id_from_bundle_descriptor(bundle_descriptor):
     bundle_desc_without_flavor = _bundle_descriptor_without_flavor(bundle_descriptor)
     return bundle_desc_without_flavor[:bundle_desc_without_flavor.rfind('-')]
+
 
 def bundle_version_from_bundle_descriptor(bundle_descriptor):
     bundle_desc_without_flavor = _bundle_descriptor_without_flavor(bundle_descriptor)
@@ -30,7 +38,10 @@ def bundle_version_from_bundle_descriptor(bundle_descriptor):
     version = int(version_flavor.split('~')[0])
     return version
 
-def file_extension_for_format(format_name):
-    if format_name == 'raw': return None
-    return format_name
+
+# TODO: move to formats.py?
+def file_extension_for_format(format):
+    if format == Formats.RAW:
+        return None
+    return format
 

--- a/src/zinc/models.py
+++ b/src/zinc/models.py
@@ -97,9 +97,9 @@ class ZincIndex(ZincModel):
         info = self._get_bundle_info(bundle_name)
         if info is None:
             info = self._bundle_info_by_name[bundle_name] = {
-                'versions':[],
-                'distributions':{},
-                'next_version':1,
+                'versions': [],
+                'distributions': {},
+                'next_version': 1,
             }
         return info
 

--- a/src/zinc/models.py
+++ b/src/zinc/models.py
@@ -2,7 +2,6 @@ import json
 import UserDict
 from functools import wraps
 
-from zinc.utils import *
 from zinc.defaults import defaults
 from zinc.pathfilter import PathFilter
 
@@ -98,10 +97,10 @@ class ZincIndex(ZincModel):
         info = self._get_bundle_info(bundle_name)
         if info is None:
             info = self._bundle_info_by_name[bundle_name] = {
-                    'versions':[],
-                    'distributions':{},
-                    'next_version':1,
-                    }
+                'versions':[],
+                'distributions':{},
+                'next_version':1,
+            }
         return info
 
     @mutable_only
@@ -111,7 +110,7 @@ class ZincIndex(ZincModel):
             next_version = self.next_version_for_bundle(bundle_name)
             if version != next_version:
                 raise Exception("Expected next bundle version %d, got version %d"
-                                % (verison, next_version))
+                                % (version, next_version))
             bundle_info['versions'].append(version)
             bundle_info['versions'] = sorted(bundle_info['versions'])
             bundle_info['next_version'] = version + 1

--- a/src/zinc/services/__init__.py
+++ b/src/zinc/services/__init__.py
@@ -5,6 +5,7 @@ import tempfile
 
 from zinc.models import ZincIndex, ZincManifest, ZincCatalogConfig
 from zinc.catalog import ZincAbstractCatalog, ZincCatalogPathHelper
+from zinc.formats import Formats
 
 from zinc.defaults import defaults
 from zinc.utils import *
@@ -170,10 +171,10 @@ class ZincCatalog(ZincAbstractCatalog):
         return self._storage.get(subpath)
 
     def _write_file(self, sha, src_path, format=None):
-        format = format or 'raw' # default to 'raw'
+        format = format or Formats.RAW # default to RAW
         if format not in defaults['catalog_valid_formats']:
             raise Exception("Invalid format '%s'." % (format))
-        ext = format if format != 'raw' else None
+        ext = format if format != Formats.RAW else None
         subpath = self._ph.path_for_file_with_sha(sha, ext)
         with open(src_path, 'r') as src_file:
             self._storage.put(subpath, src_file)
@@ -297,11 +298,11 @@ class ZincCatalog(ZincAbstractCatalog):
             if src_size > 0 and float(src_gz_size) / src_size <= self.config.gzip_threshhold:
                 final_src_path = src_path_gz
                 final_src_size = src_gz_size
-                format = 'gz'
+                format = Formats.GZ
             else:
                 final_src_path = src_path
                 final_src_size = src_size
-                format = 'raw'
+                format = Formats.RAW
 
             imported_path = self._write_file(
                     sha, final_src_path, format=format)

--- a/src/zinc/services/__init__.py
+++ b/src/zinc/services/__init__.py
@@ -410,8 +410,10 @@ class ZincCatalog(ZincAbstractCatalog):
 
 ################################################################################
 
+
 class ZincServiceProvider(object):
     pass
+
 
 class ZincServiceConsumer(object):
 

--- a/src/zinc/services/__init__.py
+++ b/src/zinc/services/__init__.py
@@ -1,8 +1,8 @@
 from urlparse import urlparse
 from functools import wraps
 import tempfile
+import logging
 
-import zinc
 from zinc.models import ZincIndex, ZincManifest, ZincCatalogConfig
 from zinc.catalog import ZincAbstractCatalog, ZincCatalogPathHelper
 
@@ -10,6 +10,7 @@ from zinc.defaults import defaults
 from zinc.utils import *
 from zinc.helpers import *
 
+log = logging.getLogger(__name__)
 
 ################# TEMP ######################
 
@@ -94,7 +95,7 @@ class ZincCatalog(ZincAbstractCatalog):
         self._read_config_file()
 
     def _read_config_file(self):
-        zinc.log.warn('reimplement config loading')
+        log.warn('reimplement config loading')
         self.config = ZincCatalogConfig()
         #config_path = pjoin(self.path, defaults['catalog_config_name'])
         #self.config = load_config(config_path)
@@ -207,7 +208,7 @@ class ZincCatalog(ZincAbstractCatalog):
             existing_manifest = self.manifest_for_bundle(bundle_name)
             if existing_manifest is not None \
                and existing_manifest.files.contents_are_equalivalent(filelist):
-                zinc.log.info("Found existing version with same contents.")
+                log.info("Found existing version with same contents.")
                 return existing_manifest
 
         ## verify all files in the filelist exist in the repo
@@ -311,8 +312,8 @@ class ZincCatalog(ZincAbstractCatalog):
                 'size' : final_src_size,
                 'format' : format
                 }
-        zinc.log.info("Imported %s --> %s" % (src_path, file_info))
-        zinc.log.debug("Imported path: %s" % imported_path)
+        log.info("Imported %s --> %s" % (src_path, file_info))
+        log.debug("Imported path: %s" % imported_path)
         return  file_info
 
     @_lock_index
@@ -375,7 +376,7 @@ class ZincCatalog(ZincAbstractCatalog):
                     if bundle_descr not in bundle_descriptors:
                         remove = True
                 if remove:
-                    zinc.log.info("%s %s" % (verb, pjoin(root, f)))
+                    log.info("%s %s" % (verb, pjoin(root, f)))
                     if not dry_run: os.remove(pjoin(root, f))
 
         ### 2. scan archives for ones that aren't in index
@@ -390,7 +391,7 @@ class ZincCatalog(ZincAbstractCatalog):
                     if bundle_descr not in bundle_descriptors:
                         remove = True
                 if remove:
-                    zinc.log.info("%s %s" % (verb, pjoin(root, f)))
+                    log.info("%s %s" % (verb, pjoin(root, f)))
                     if not dry_run: os.remove(pjoin(root, f))
 
         ### 3. clean objects
@@ -403,7 +404,7 @@ class ZincCatalog(ZincAbstractCatalog):
             for f in files:
                 basename = os.path.splitext(f)[0]
                 if basename not in all_objects:
-                    zinc.log.info("%s %s" % (verb, pjoin(root, f)))
+                    log.info("%s %s" % (verb, pjoin(root, f)))
                     if not dry_run: os.remove(pjoin(root, f))
 
 

--- a/src/zinc/services/__init__.py
+++ b/src/zinc/services/__init__.py
@@ -1,8 +1,8 @@
-import logging
 from urlparse import urlparse
 from functools import wraps
 import tempfile
 
+import zinc
 from zinc.models import ZincIndex, ZincManifest, ZincCatalogConfig
 from zinc.catalog import ZincAbstractCatalog, ZincCatalogPathHelper
 
@@ -94,7 +94,7 @@ class ZincCatalog(ZincAbstractCatalog):
         self._read_config_file()
 
     def _read_config_file(self):
-        logging.warn('reimplement config loading')
+        zinc.log.warn('reimplement config loading')
         self.config = ZincCatalogConfig()
         #config_path = pjoin(self.path, defaults['catalog_config_name'])
         #self.config = load_config(config_path)
@@ -207,7 +207,7 @@ class ZincCatalog(ZincAbstractCatalog):
             existing_manifest = self.manifest_for_bundle(bundle_name)
             if existing_manifest is not None \
                and existing_manifest.files.contents_are_equalivalent(filelist):
-                logging.info("Found existing version with same contents.")
+                zinc.log.info("Found existing version with same contents.")
                 return existing_manifest
 
         ## verify all files in the filelist exist in the repo
@@ -311,8 +311,8 @@ class ZincCatalog(ZincAbstractCatalog):
                 'size' : final_src_size,
                 'format' : format
                 }
-        logging.info("Imported %s --> %s" % (src_path, file_info))
-        logging.debug("Imported path: %s" % imported_path)
+        zinc.log.info("Imported %s --> %s" % (src_path, file_info))
+        zinc.log.debug("Imported path: %s" % imported_path)
         return  file_info
 
     @_lock_index
@@ -375,7 +375,7 @@ class ZincCatalog(ZincAbstractCatalog):
                     if bundle_descr not in bundle_descriptors:
                         remove = True
                 if remove:
-                    logging.info("%s %s" % (verb, pjoin(root, f)))
+                    zinc.log.info("%s %s" % (verb, pjoin(root, f)))
                     if not dry_run: os.remove(pjoin(root, f))
 
         ### 2. scan archives for ones that aren't in index
@@ -390,7 +390,7 @@ class ZincCatalog(ZincAbstractCatalog):
                     if bundle_descr not in bundle_descriptors:
                         remove = True
                 if remove:
-                    logging.info("%s %s" % (verb, pjoin(root, f)))
+                    zinc.log.info("%s %s" % (verb, pjoin(root, f)))
                     if not dry_run: os.remove(pjoin(root, f))
 
         ### 3. clean objects
@@ -403,7 +403,7 @@ class ZincCatalog(ZincAbstractCatalog):
             for f in files:
                 basename = os.path.splitext(f)[0]
                 if basename not in all_objects:
-                    logging.info("%s %s" % (verb, pjoin(root, f)))
+                    zinc.log.info("%s %s" % (verb, pjoin(root, f)))
                     if not dry_run: os.remove(pjoin(root, f))
 
 

--- a/src/zinc/services/__init__.py
+++ b/src/zinc/services/__init__.py
@@ -417,8 +417,26 @@ class ZincServiceProvider(object):
 
 class ZincServiceConsumer(object):
 
+    def __init__(self, **kwargs):
+        pass
+
     def create_catalog(self, id=None, loc=None):
         raise NotImplementedError()
 
     def get_catalog(self, loc=None, id=None):
         raise NotImplementedError()
+
+
+class CustomServiceConsumer(ZincServiceConsumer):
+
+    def __init__(self, coordinator=None, storage=None, **kwargs):
+        assert coordinator
+        assert storage
+
+        self._coordinator = coordinator
+        self._storage = storage
+
+    def get_catalog(self, loc=None, id=None):
+        cat_storage = self._storage.bind_to_catalog(loc=loc, id=id)
+        # TODO: bind to coordinator?
+        return ZincCatalog(coordinator=self._coordinator, storage=cat_storage)

--- a/src/zinc/services/simple.py
+++ b/src/zinc/services/simple.py
@@ -9,6 +9,7 @@ from zinc.defaults import defaults
 from zinc.utils import *
 from zinc.helpers import *
 
+
 def f(service, conn, command):
     conn.send("fart")
     conn.close()
@@ -20,7 +21,6 @@ def _get_index(url, conn):
     catalog = ZincCatalog(coordinator=coordinator, storage=storage)
     conn.send(catalog.get_index())
     conn.close()
-
 
 
 class SimpleServiceConsumer(ZincServiceConsumer):
@@ -37,7 +37,7 @@ class SimpleServiceConsumer(ZincServiceConsumer):
 
         path = self._abs_path(loc)
         makedirs(path)
-        
+
         config_path = os.path.join(path, defaults['catalog_config_name'])
         ZincCatalogConfig().write(config_path)
 

--- a/src/zinc/services/web/__init__.py
+++ b/src/zinc/services/web/__init__.py
@@ -2,7 +2,6 @@
 #from flask import Flask, request, redirect, abort
 import requests
 from urlparse import urljoin
-import os
 
 from zinc.catalog import ZincAbstractCatalog
 from zinc.models import ZincIndex, ZincManifest
@@ -23,23 +22,23 @@ class WebServiceZincCatalog(ZincAbstractCatalog):
         return urljoin(self._service_consumer.url, path)
 
     def get_index(self):
-        path = self.id #+ '/index.json' # TODO: improve this
+        path = self.id  # + '/index.json' # TODO: improve this
         url = self._url_for_path(path)
         r = requests.get(url)
         return ZincIndex.from_bytes(r.content, mutable=False)
 
     def get_manifest(self, bundle_name, version):
-        path = self.id + '/' + bundle_name + '/' + str(version) # TODO: improve this
+        path = self.id + '/' + bundle_name + '/' + str(version)  # TODO: improve this
         url = self._url_for_path(path)
         r = requests.get(url)
         return ZincManifest.from_bytes(r.content, mutable=False)
 
-    def update_bundle(self, bundle_name, filelist, 
-            skip_master_archive=False, force=False):
+    def update_bundle(self, bundle_name, filelist, skip_master_archive=False,
+                      force=False):
         # TODO: implement flags
-        path = self.id + '/' + bundle_name + '/' # TODO: improve this
+        path = self.id + '/' + bundle_name + '/'  # TODO: improve this
         url = self._url_for_path(path)
-        data = { 'files' : filelist.to_bytes()}
+        data = {'files': filelist.to_bytes()}
         requests.post(url, data=data)
 
     def update_distribution(self, distribution_name, bundle_name, bundle_version):
@@ -58,6 +57,7 @@ class WebServiceZincCatalog(ZincAbstractCatalog):
         # TODO: real error
         if r.status_code / 100 != 2:
             raise Exception("didn't work!")
+
 
 class WebServiceConsumer(ZincServiceConsumer):
 

--- a/src/zinc/storages/__init__.py
+++ b/src/zinc/storages/__init__.py
@@ -1,4 +1,5 @@
-from StringIO import StringIO 
+from StringIO import StringIO
+
 
 class StorageBackend(object):
 
@@ -8,11 +9,11 @@ class StorageBackend(object):
         self.put(subpath, fileobj)
 
     ## Methods to override
-    
+
     def get(self, subpath):
         """Return file-like object at subpath."""
         raise NotImplementedError()
-    
+
     def get_meta(self, subpath):
         """
         Return dictionary of metadata for item at subpath or None if subpath

--- a/src/zinc/storages/__init__.py
+++ b/src/zinc/storages/__init__.py
@@ -3,6 +3,26 @@ from StringIO import StringIO
 
 class StorageBackend(object):
 
+    def __init__(self, url=None, **kwargs):
+
+        if url is not None:
+            assert self.valid_url(url)
+            self._url = url
+        else:
+            self._url = None
+
+    @classmethod
+    def valid_url(cls, url):
+        raise NotImplementedError()
+
+    @property
+    def url(self):
+        return self._url
+
+    # TODO: think of a better name
+    def bind_to_catalog(self, loc=None, id=None):
+        raise NotImplementedError()
+
     def puts(self, subpath, bytes):
         """Write string 'bytes' to subpath."""
         fileobj = StringIO(bytes)
@@ -29,3 +49,12 @@ class StorageBackend(object):
         raise NotImplementedError()
 
 
+def storage_for_url(url):
+    from .filesystem import FilesystemStorageBackend
+    from .aws import S3StorageBackend
+
+    storage_classes = (FilesystemStorageBackend, S3StorageBackend)
+
+    for storage_class in storage_classes:
+        if storage_class.valid_url(url):
+            return storage_class

--- a/src/zinc/storages/aws.py
+++ b/src/zinc/storages/aws.py
@@ -4,6 +4,7 @@ from boto.s3.key import Key
 
 from . import StorageBackend
 
+
 class S3StorageBackend(StorageBackend):
 
     def __init__(self, s3connection=None, bucket=None, prefix=None, **kwargs):
@@ -21,13 +22,12 @@ class S3StorageBackend(StorageBackend):
             return subpath
 
     def get(self, subpath):
-        return self._bucket.get_key(
-                self._get_keyname(subpath))
+        return self._bucket.get_key(self._get_keyname(subpath))
 
     def get_meta(self, subpath):
-        key = self._bucket.lookup(
-                self._get_keyname(subpath))
-        if key is None: return None
+        key = self._bucket.lookup(self._get_keyname(subpath))
+        if key is None:
+            return None
         meta = dict()
         meta['size'] = key.size
         return meta
@@ -36,4 +36,3 @@ class S3StorageBackend(StorageBackend):
         k = Key(self._bucket)
         k.key = self._get_keyname(subpath)
         k.set_contents_from_file(fileobj)
-

--- a/src/zinc/storages/aws.py
+++ b/src/zinc/storages/aws.py
@@ -1,19 +1,38 @@
 import os
+from copy import copy
+from urlparse import urlparse
 
 from boto.s3.key import Key
+from boto.s3.connection import S3Connection
 
 from . import StorageBackend
 
 
 class S3StorageBackend(StorageBackend):
 
-    def __init__(self, s3connection=None, bucket=None, prefix=None, **kwargs):
-        assert s3connection
-        assert bucket
+    def __init__(self, url=None, aws_key=None, aws_secret=None,
+                 s3connection=None, bucket=None, prefix=None, **kwargs):
+
         super(S3StorageBackend, self).__init__(**kwargs)
-        self._conn = s3connection
-        self._bucket = self._conn.get_bucket(bucket)
+
+        assert s3connection or (aws_key and aws_secret)
+        self._conn = s3connection or S3Connection(aws_key, aws_secret)
+
+        assert bucket or url
+        bucket_name = bucket or urlparse(url).netloc
+
+        self._bucket = self._conn.get_bucket(bucket_name)
         self._prefix = prefix
+
+    @classmethod
+    def valid_url(cls, url):
+        return urlparse(url).scheme in ('s3')
+
+    def bind_to_catalog(self, loc=None, id=None):
+        assert id
+        cpy = copy(self)
+        cpy._prefix = id
+        return cpy
 
     def _get_keyname(self, subpath):
         if self._prefix:

--- a/src/zinc/storages/filesystem.py
+++ b/src/zinc/storages/filesystem.py
@@ -5,6 +5,7 @@ from atomicfile import AtomicFile
 from . import StorageBackend
 from zinc.utils import *
 
+
 class FilesystemStorageBackend(StorageBackend):
 
     def __init__(self, url=None):
@@ -23,7 +24,7 @@ class FilesystemStorageBackend(StorageBackend):
 
     def get(self, subpath):
         abs_path = self._abs_path(subpath)
-        f =  open(abs_path, 'r')
+        f = open(abs_path, 'r')
         return f
 
     def get_meta(self, subpath):
@@ -39,4 +40,3 @@ class FilesystemStorageBackend(StorageBackend):
         makedirs(os.path.dirname(abs_path))
         with AtomicFile(abs_path, 'w') as f:
             f.write(fileobj.read())
-

--- a/src/zinc/storages/filesystem.py
+++ b/src/zinc/storages/filesystem.py
@@ -8,9 +8,14 @@ from zinc.utils import *
 
 class FilesystemStorageBackend(StorageBackend):
 
-    def __init__(self, url=None):
+    def __init__(self, url=None, **kwargs):
+        super(FilesystemStorageBackend, self).__init__(**kwargs)
         assert url is not None
         self._url = url
+
+    @classmethod
+    def valid_url(cls, url):
+        return urlparse(url).scheme in ('file')
 
     @property
     def url(self):

--- a/src/zinc/tasks/bundle_clone.py
+++ b/src/zinc/tasks/bundle_clone.py
@@ -1,7 +1,7 @@
 import os
-import logging
 from shutil import copyfile
 
+import zinc
 from zinc.utils import *
 from zinc.helpers import *
 
@@ -9,8 +9,8 @@ from zinc.helpers import *
 
 class ZincBundleCloneTask(object):
 
-    def __init__(self, 
-            catalog=None, 
+    def __init__(self,
+            catalog=None,
             bundle_name=None,
             version=None,
             output_path=None,
@@ -38,12 +38,12 @@ class ZincBundleCloneTask(object):
         assert self.bundle_name
         assert self.version
         assert self.output_path
-    
+
         manifest = self.catalog.manifest_for_bundle(
                 self.bundle_name, self.version)
 
         if manifest is None:
-            raise Exception("manifest not found: %s-%d" % 
+            raise Exception("manifest not found: %s-%d" %
                     (self.bundle_name, self.version))
 
         if self.flavor is not None and self.flavor not in manifest.flavors:
@@ -66,7 +66,7 @@ class ZincBundleCloneTask(object):
             sha = manifest.sha_for_file(file)
 
             makedirs(os.path.dirname(dst_path))
-            
+
             if formats.get('raw') is not None:
                 src_path = self.catalog._path_for_file_with_sha(sha)
                 copyfile(src_path, dst_path)
@@ -74,7 +74,7 @@ class ZincBundleCloneTask(object):
                 src_path = self.catalog._path_for_file_with_sha(sha, ext='gz')
                 gunzip(src_path, dst_path)
 
-            logging.info("Exported %s --> %s" % (src_path, dst_path))
+            zinc.log.info("Exported %s --> %s" % (src_path, dst_path))
 
-        logging.info("Exported %d files to '%s'" % (len(all_files), root_dir))
+        zinc.log.info("Exported %d files to '%s'" % (len(all_files), root_dir))
 

--- a/src/zinc/tasks/bundle_clone.py
+++ b/src/zinc/tasks/bundle_clone.py
@@ -2,6 +2,7 @@ import os
 import logging
 from shutil import copyfile
 
+from zinc.formats import Formats
 from zinc.utils import *
 from zinc.helpers import *
 
@@ -9,8 +10,8 @@ from zinc.helpers import *
 
 class ZincBundleCloneTask(object):
 
-    def __init__(self, 
-            catalog=None, 
+    def __init__(self,
+            catalog=None,
             bundle_name=None,
             version=None,
             output_path=None,
@@ -38,12 +39,12 @@ class ZincBundleCloneTask(object):
         assert self.bundle_name
         assert self.version
         assert self.output_path
-    
+
         manifest = self.catalog.manifest_for_bundle(
                 self.bundle_name, self.version)
 
         if manifest is None:
-            raise Exception("manifest not found: %s-%d" % 
+            raise Exception("manifest not found: %s-%d" %
                     (self.bundle_name, self.version))
 
         if self.flavor is not None and self.flavor not in manifest.flavors:
@@ -66,11 +67,11 @@ class ZincBundleCloneTask(object):
             sha = manifest.sha_for_file(file)
 
             makedirs(os.path.dirname(dst_path))
-            
-            if formats.get('raw') is not None:
+
+            if formats.get(Formats.RAW) is not None:
                 src_path = self.catalog._path_for_file_with_sha(sha)
                 copyfile(src_path, dst_path)
-            elif formats.get('gz') is not None:
+            elif formats.get(Formats.GZ) is not None:
                 src_path = self.catalog._path_for_file_with_sha(sha, ext='gz')
                 gunzip(src_path, dst_path)
 

--- a/src/zinc/tasks/bundle_clone.py
+++ b/src/zinc/tasks/bundle_clone.py
@@ -1,9 +1,12 @@
 import os
 from shutil import copyfile
+import logging
 
 import zinc
 from zinc.utils import *
 from zinc.helpers import *
+
+log = logging.getLogger(__name__)
 
 ## TODO: this is broken and needs to be tested too
 
@@ -74,7 +77,7 @@ class ZincBundleCloneTask(object):
                 src_path = self.catalog._path_for_file_with_sha(sha, ext='gz')
                 gunzip(src_path, dst_path)
 
-            zinc.log.info("Exported %s --> %s" % (src_path, dst_path))
+            log.info("Exported %s --> %s" % (src_path, dst_path))
 
-        zinc.log.info("Exported %d files to '%s'" % (len(all_files), root_dir))
+        log.info("Exported %d files to '%s'" % (len(all_files), root_dir))
 

--- a/src/zinc/utils.py
+++ b/src/zinc/utils.py
@@ -13,6 +13,9 @@ import gzip
 import zlib
 import os
 
+def enum(**enums):
+    return type('Enum', (), enums)
+
 def sha1_for_path(path):
     """Returns the SHA1 hash as a string for the given path."""
     sha1 = hashlib.sha1()

--- a/tests/fixtures/zinc-client.config
+++ b/tests/fixtures/zinc-client.config
@@ -3,9 +3,9 @@
 
 local_password = "abc123"
 
-[bookmarks.remote]
+[bookmark.remote]
 ref = "http://foo.com/catalog/"
 
-[bookmarks.local]
+[bookmark.local]
 ref = "/tmp/catalog"
 password = "vars.local_password"

--- a/tests/testZincCatalog.py
+++ b/tests/testZincCatalog.py
@@ -24,7 +24,8 @@ class StorageBackendTestCase(unittest.TestCase):
         self.assertRaises(NotImplementedError, self.storage.get_meta, 'foo')
 
     def test_put_raises(self):
-        self.assertRaises(NotImplementedError, self.storage.put , 'foo', 'bar')
+        self.assertRaises(NotImplementedError, self.storage.put, 'foo', 'bar')
+
 
 def create_catalog_at_path(path, id):
     service = connect('/')
@@ -83,7 +84,7 @@ class ZincCatalogTestCase(TempDirTestCase):
         create_random_file(self.scratch_dir)
         create_random_file(self.scratch_dir)
         create_bundle_version(catalog, "meep", self.scratch_dir)
-        catalog._reload() # TODO: fix/remove/something
+        catalog._reload()  # TODO: fix/remove/something
         return catalog
 
     def test_create_bundle_version(self):
@@ -145,8 +146,8 @@ class ZincCatalogTestCase(TempDirTestCase):
         manifest1 = create_bundle_version(catalog, "meep", self.scratch_dir)
         self.assertTrue(2 in catalog.get_index().versions_for_bundle("meep"))
         # attempt to create same version again, with force
-        manifest2 = create_bundle_version(catalog,
-                "meep", self.scratch_dir, force=True)
+        manifest2 = create_bundle_version(catalog, "meep", self.scratch_dir,
+                                          force=True)
         self.assertNotEquals(manifest1.version, manifest2.version)
 
     def test_create_identical_bundle_version(self):


### PR DESCRIPTION
- added `coordinator_for_url` and `storage_for_url` helper methods to find the right storage class for a give url. These can probably be improved.
- renamed `validate_url` to `valid_url`
- added url validate to StorageBackends
- integrated custom config loading with `catalog:list` command

`.zinc` looks like this:

```
[vars]
aws_key = "blah"
aws_secret = "blahgggg"

[storage.dev]
url = "s3://zinc-demo"
aws_key = "vars.aws_key"
aws_secret = "vars.aws_secret"

[coordinator.dev]
url = "redis://localhost:6379"
redis_password = "blah"

[bookmark.demo1]
catalog_id = "com.mindsnacks.demo1"
storage = "dev"
coordinator = "dev"

```

The meat of it is in this commit: https://github.com/mindsnacks/Zinc/commit/9aab84b0371ee2e85e4b7f263e8a24cf4eed7fa0

The rest is just code formatting.

---

Example usage with using `.zinc` and bookmarks:

```
$ zinc catalog:list -c demo1
test1 [2=(master)]
sphalerites [1, 2, 3, 4=(master)]
cats [1=(master)]
dogs [1=(master), 2=(test)]


$ zinc bundle:list -c demo1 -b cats -v 1
kucing.jpeg
lime-cat.jpeg
```
