### PR TITLE
Basic simpledb-based catalog coordinator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 atomicfile==0.1
 lockfile==0.9.1
+boto==2.8.0

--- a/src/zinc/coordinators/__init__.py
+++ b/src/zinc/coordinators/__init__.py
@@ -28,8 +28,11 @@ def coordinator_for_url(url):
     # TODO: better way to search for coordinators
     from .filesystem import FilesystemCatalogCoordinator
     from .redis import RedisCatalogCoordinator
+    from .aws import SimpleDBCatalogCoordinator
 
-    coord_classes = (FilesystemCatalogCoordinator, RedisCatalogCoordinator)
+    coord_classes = (FilesystemCatalogCoordinator,
+                     RedisCatalogCoordinator,
+                     SimpleDBCatalogCoordinator)
 
     for coord_class in coord_classes:
         if coord_class.valid_url(url):

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -18,7 +18,9 @@ LOCK_TIME = 'lock_time'
 class Lock(object):
     def __init__(self, sdb_domain, key, expires=300, timeout=10):
 
-        assert expires > timeout and expires > 30
+        # Expiration must be 0 (never) or at least 30 seconds and greater than
+        # the timeout
+        assert expires == 0 or (expires > timeout and expires >= 30)
 
         self._sdb_domain = sdb_domain
         self._key = key
@@ -33,7 +35,7 @@ class Lock(object):
                 item = self._sdb_domain.get_item(self._key, consistent_read=True)
 
                 # check expiration
-                if item is not None:
+                if item is not None and self._expires != 0:
                     lock_time = item.get(LOCK_TIME)
                     if lock_time is None \
                        or time.time() > float(lock_time) + self._expires:

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -1,0 +1,114 @@
+from urlparse import urlparse
+import random
+import time
+import uuid
+import logging
+
+from boto.sdb import connect_to_region
+from boto.exception import SDBResponseError
+
+from . import CatalogCoordinator
+
+log = logging.getLogger(__name__)
+
+LOCK_TOKEN = 'lock_token'
+LOCK_TIME = 'lock_time'
+
+
+class Lock(object):
+    def __init__(self, sdb_domain, key, expires=300, timeout=10):
+
+        assert expires > timeout and expires > 30
+
+        self._sdb_domain = sdb_domain
+        self._key = key
+        self._timeout = timeout
+        self._expires = expires
+        self._token = str(uuid.uuid1())
+
+    def __enter__(self):
+        timeout = self._timeout
+        while timeout >= 0:
+            try:
+                item = self._sdb_domain.get_item(self._key, consistent_read=True)
+
+                # check expiration
+                if item is not None:
+                    lock_time = item.get(LOCK_TIME)
+                    if lock_time is None \
+                       or time.time() > float(lock_time) + self._expires:
+                        log.info('Clearing expired lock...')
+                        self._sdb_domain.delete_attributes(
+                            self._key, [LOCK_TOKEN, LOCK_TIME],
+                            expected_values=[LOCK_TOKEN, item[LOCK_TOKEN]])
+
+                # try to get the lock
+                if item is None or item.get(LOCK_TOKEN) is None:
+                    attrs = {
+                        LOCK_TOKEN: self._token,
+                        LOCK_TIME: time.time() + self._expires
+                    }
+                    self._sdb_domain.put_attributes(
+                        self._key, attrs,
+                        expected_value=[LOCK_TOKEN, False])
+                    return
+
+                timeout -= 1
+                if timeout >= 0:
+                    log.debug('Sleeping')
+                    time.sleep(1)
+
+            except SDBResponseError, sdberr:
+                if sdberr.status == 409:
+                    pass  # we will retry
+                else:
+                    raise sdberr
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        item = self._sdb_domain.get_item(self._key, consistent_read=True)
+        if item is not None and item[LOCK_TOKEN] == self._token:
+            self._sdb_domain.delete_attributes(
+                self._key, [LOCK_TOKEN, LOCK_TIME],
+                expected_values=[LOCK_TOKEN, self._token])
+        else:
+            raise LockException("Failed to acquire lock within timeout.")
+
+
+################################################################################
+
+
+class LockException(Exception):
+    pass
+
+################################################################################
+
+
+class SimpleDBCatalogCoordinator(CatalogCoordinator):
+
+    def __init__(self, url=None, aws_key=None, aws_secret=None,
+                 sdb_connection=None, **kwargs):
+
+        super(SimpleDBCatalogCoordinator, self).__init__(**kwargs)
+
+        assert sdb_connection or (aws_key and aws_secret)
+
+        urlcomps = urlparse(url)
+        sdb_region = urlcomps.netloc
+        sdb_domain = urlcomps.path[1:]  # strip leading /
+        if sdb_domain == '':
+            sdb_domain = 'zinc'
+
+        self._conn = connect_to_region(sdb_region,
+                                       aws_access_key_id=aws_key,
+                                       aws_secret_access_key=aws_secret)
+        self._domain = self._conn.create_domain(sdb_domain)
+
+    def get_index_lock(self, domain=None):
+        assert domain
+        return Lock(self._domain, domain)
+
+    @classmethod
+    def valid_url(cls, url):
+        urlcomps = urlparse(url)
+        # TODO: validate region
+        return urlcomps.scheme == 'sdb'

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -4,7 +4,7 @@ import time
 import uuid
 import logging
 
-from boto.sdb import connect_to_region
+import boto.sdb
 from boto.exception import SDBResponseError
 
 from . import CatalogCoordinator
@@ -100,9 +100,9 @@ class SimpleDBCatalogCoordinator(CatalogCoordinator):
         if sdb_domain == '':
             sdb_domain = 'zinc'
 
-        self._conn = connect_to_region(sdb_region,
-                                       aws_access_key_id=aws_key,
-                                       aws_secret_access_key=aws_secret)
+        self._conn = boto.sdb.connect_to_region(sdb_region,
+                                                aws_access_key_id=aws_key,
+                                                aws_secret_access_key=aws_secret)
         self._domain = self._conn.create_domain(sdb_domain)
 
     def get_index_lock(self, domain=None):
@@ -112,5 +112,5 @@ class SimpleDBCatalogCoordinator(CatalogCoordinator):
     @classmethod
     def valid_url(cls, url):
         urlcomps = urlparse(url)
-        # TODO: validate region
-        return urlcomps.scheme == 'sdb'
+        return urlcomps.scheme == 'sdb' \
+                and urlcomps.netloc in [r.name for r in boto.sdb.regions()]

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -48,7 +48,7 @@ class Lock(object):
                 if item is None or item.get(LOCK_TOKEN) is None:
                     attrs = {
                         LOCK_TOKEN: self._token,
-                        LOCK_TIME: time.time() + self._expires
+                        LOCK_TIME: time.time()
                     }
                     self._sdb_domain.put_attributes(
                         self._key, attrs,


### PR DESCRIPTION
Some inspiration was taken from: https://github.com/pLucky-Inc/sdb_lock
# How it works:
## Acquiring a lock

When a lock is acquired it writes two key/value pairs under a SimpleDB item named with the catalog id. `lock_token` uniquely identifies the lock holder. `lock_time` is the timestamp in seconds since the epoch in GMT from when the lock was acquired.

```
`com.mindsnacks.stuff: {
    'lock_token': 1231231,
    'lock_time: 123123123211.2.
  }
```

To acquire a lock, it attempts to put new `lock_token` and `lock_time` keys _with the expectation that `lock_token` is unset_. This is done atomically using SimpleDB's expected value supported: http://aws.amazon.com/articles/3572?_encoding=UTF8&jiveRedirect=1

If it if the lock is not acquired successfully, it retries every second for a number of seconds specified by the supplied timeout.
## Releasing the lock

When the critical section completes, it attempts to delete the `lock_token` and `lock_time` keys _with the expectation that the `lock_token` in SimpleDB matches the local token_. Again, this is done atomically with SimpleDB's consistency enhancements. 
## Expiration

SimpleDB does not have any built-in way to expire locks, therefor the client must do this itself. Catalog locks in Zinc are currently intended to be short lived, so any lock that has not been released for a long time is likely to be expired. 

Before acquiring a lock, it first checks for expiration if the existing `lock_time` is beyond the expiration time, the lock is cleared, and then it will attempt to acquire the lock the normal way.

This is definitely the most dangerous part, but I couldn't think of another solution.
## 

Here's what a `.zinc` looks like

```
[vars]
    aws_key = "key"
    aws_secret = "secret"

[storage.dev]
    url = "s3://zinc-demo"
    aws_key = "vars.aws_key"
    aws_secret = "vars.aws_secret"

[coordinator.dev]
    url = "sdb://us-east-1"
    aws_key = "vars.aws_key"
    aws_secret = "vars.aws_secret"

[bookmark.demo1]
    catalog_id = "com.mindsnacks.demo1"
    storage = "dev"
    coordinator = "dev"
```
