### PR TITLE
Adding "dump:index" and "dump:manifest" commands

### DIFF
--- a/src/zinc/cli.py
+++ b/src/zinc/cli.py
@@ -300,6 +300,38 @@ def subcmd_catalog_verify(config, args):
             print r
 
 
+def _dump_json(catalog, subpath, dest_path=None, should_decompress=True):
+
+    subpath_gz = helpers.append_file_extension_for_format(subpath, Formats.GZ)
+    data = catalog._read(subpath_gz)  # TODO: fix private method references
+    if should_decompress:
+        out = utils.gunzip_bytes(data)
+    else:
+        out = data
+
+    if dest_path is not None:
+        name = os.path.split(subpath)[-1]
+        with open(name, 'w+b') as f:
+            f.write(out)
+        log.info('Wrote %s' % (name))
+    else:
+        print out
+
+def subcmd_dump_index(config, args):
+    catalog = get_catalog(config, args)
+
+    # TODO: fix private method references
+    subpath = catalog._ph.path_for_index()
+
+    if args.remote_name:
+        dest_path = os.path.split(subpath)[-1]
+    else:
+        dest_path = None
+
+    _dump_json(catalog, subpath, should_decompress=not args.no_decompress,
+            dest_path=dest_path)
+
+
 def subcmd_dump_manifest(config, args):
     catalog = get_catalog(config, args)
     bundle_name = args.bundle
@@ -307,21 +339,16 @@ def subcmd_dump_manifest(config, args):
 
     # TODO: fix private method references
     subpath = catalog._ph.path_for_manifest_for_bundle_version(bundle_name, version)
-    subpath_gz = helpers.append_file_extension_for_format(subpath, Formats.GZ)
-    data = catalog._read(subpath_gz)
-
-    if args.no_decompress:
-        out = data
-    else:
-        out = utils.gunzip_bytes(data)
 
     if args.remote_name:
-        name = os.path.split(subpath)[-1]
-        with open(name, 'w+b') as f:
-            f.write(out)
-        log.info('Wrote %s' % (name))
+        dest_path = os.path.split(subpath)[-1]
     else:
-        print out
+        dest_path = None
+
+    _dump_json(catalog, subpath, should_decompress=not args.no_decompress,
+            dest_path=dest_path)
+
+
 
 
 
@@ -354,6 +381,13 @@ def main():
     add_timeout_arg = lambda parser, required=False: parser.add_argument(
         '--timeout', required=required, default=None,
         help='Timeout for acquiring catalog locks. 0 = wait forever.')
+    add_remote_name_arg = lambda parser, required=False: parser.add_argument(
+            '-O', '--remote-name', required=required, default=False,
+                action='store_true', help='Write to file using remote name \
+                instead of stdout.')
+    add_no_decompress_arg = lambda parser, required=False: parser.add_argument(
+            '--no-decompress', required=required, default=False,
+            action='store_true', help='Don\'t decompress file after downloading.')
 
     # catalog:create
     parser_catalog_create = subparsers.add_parser(
@@ -485,17 +519,22 @@ def main():
     add_distro_arg(parser_distro_delete)
     parser_distro_delete.set_defaults(func=subcmd_distro_delete)
 
+    # dump:index
+    parser_dump_index = subparsers.add_parser(
+            'dump:index', help='Dump catalog index file (catalog.json).')
+    add_catalog_arg(parser_dump_index)
+    add_remote_name_arg(parser_dump_index)
+    add_no_decompress_arg(parser_dump_index)
+    parser_dump_index.set_defaults(func=subcmd_dump_index)
+
     # dump:manifest
     parser_dump_manifest = subparsers.add_parser(
-            'dump:manifest', help='Dump a manifest file from a catalog')
+            'dump:manifest', help='Dump a manifest file from a catalog.')
     add_catalog_arg(parser_dump_manifest)
     add_bundle_arg(parser_dump_manifest)
     add_version_arg(parser_dump_manifest)
-    parser_dump_manifest.add_argument('-O', '--remote-name', default=False,
-            action='store_true',
-            help='Write to file using remote name instead of stdout')
-    parser_dump_manifest.add_argument('--no-decompress', default=False,
-            action='store_true', help='Don\'t decompress file.')
+    add_remote_name_arg(parser_dump_manifest)
+    add_no_decompress_arg(parser_dump_manifest)
     parser_dump_manifest.set_defaults(func=subcmd_dump_manifest)
 
     args = parser.parse_args()

--- a/src/zinc/cli.py
+++ b/src/zinc/cli.py
@@ -4,7 +4,6 @@ import logging
 import os
 import sys
 from urlparse import urlparse
-import requests
 
 from zinc.utils import canonical_path
 from zinc.client import (ZincClientConfig, connect, create_bundle_version,

--- a/src/zinc/helpers.py
+++ b/src/zinc/helpers.py
@@ -42,9 +42,28 @@ def bundle_version_from_bundle_descriptor(bundle_descriptor):
 
 # TODO: move to formats.py?
 def file_extension_for_format(format):
+    """Returns proper file extension for the given format, or `None` if no
+    extension is necessary."""
+
     if format == Formats.RAW:
         return None
     return format
+
+
+def append_file_extension(path, ext):
+    """Appends the given extension to the path. If `ext` is `None`,
+    `path` is returned."""
+
+    if ext is not None:
+        return '%s.%s' % (path, ext)
+    return path
+
+
+def append_file_extension_for_format(path, format):
+    """Appends the proper filename extension for the given format."""
+
+    ext = file_extension_for_format(format)
+    return append_file_extension(path, ext)
 
 
 def distro_previous_name(distro_name):

--- a/src/zinc/tasks/bundle_update.py
+++ b/src/zinc/tasks/bundle_update.py
@@ -37,7 +37,7 @@ def _build_archive(catalog, manifest, src_dir, flavor=None):
             ext = helpers.file_extension_for_format(format)
 
             tarinfo = tar.tarinfo()
-            tarinfo.name = utils.filename_with_ext(sha, ext)
+            tarinfo.name = helpers.append_file_extension(sha, ext)
 
             path = os.path.join(src_dir, f)
 

--- a/src/zinc/utils.py
+++ b/src/zinc/utils.py
@@ -81,11 +81,5 @@ def gunzip_bytes(bytes):
     return zlib.decompress(bytes, 16 + zlib.MAX_WBITS)
 
 
-def filename_with_ext(filename, ext):
-    if ext is not None:
-        return '%s.%s' % (filename, ext)
-    return filename
-
-
 def file_url(path):
     return 'file://%s' % (canonical_path(path))


### PR DESCRIPTION
```
usage: zinc dump:manifest [-h] -c CATALOG -b BUNDLE -v VERSION [-O]
                          [--no-decompress]

optional arguments:
  -h, --help            show this help message and exit
  -c CATALOG, --catalog CATALOG
                        Catalog reference.
  -b BUNDLE, --bundle BUNDLE
                        Bundle name.
  -v VERSION, --version VERSION
                        Version.
  -O, --remote-name     Write to file using remote name instead of stdout
  --no-decompress       Don't decompress file
```

```
usage: zinc dump:index [-h] -c CATALOG [-O] [--no-decompress]

optional arguments:
  -h, --help            show this help message and exit
  -c CATALOG, --catalog CATALOG
                        Catalog reference.
  -O, --remote-name     Write to file using remote name instead of stdout.
  --no-decompress       Don't decompress file after downloading.
```

Example:

```
$ zinc dump:manifest -c games -b pancakes -v latest
```

Would dump the manifest json to stdout
