### PR TITLE
Validate certs when connecting to region and creating connection

### DIFF
--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -142,7 +142,7 @@ class SimpleDBCatalogCoordinator(CatalogCoordinator):
         self._conn = boto.sdb.connect_to_region(sdb_region,
                                                 aws_access_key_id=aws_key,
                                                 aws_secret_access_key=aws_secret,
-                                                validate_certs=False)
+                                                validate_certs=True)
         self._domain = self._conn.create_domain(sdb_domain)
 
     def get_index_lock(self, domain=None, timeout=None, **kwargs):

--- a/src/zinc/services/web/server.py
+++ b/src/zinc/services/web/server.py
@@ -19,7 +19,7 @@ from config import CONFIG
 API_VERSION = '1.0'
 REDIS_URL = os.environ.get('REDISTOGO_URL', 'redis://localhost:6379')
 REDIS = Redis.from_url(REDIS_URL)
-S3 = S3Connection(CONFIG['aws_key'], CONFIG['aws_secret'])
+S3 = S3Connection(CONFIG['aws_key'], CONFIG['aws_secret'], validate_certs=True)
 
 Coordinator = RedisCatalogCoordinator(redis=REDIS)
 Q = Queue(connection=REDIS)

--- a/src/zinc/storages/aws.py
+++ b/src/zinc/storages/aws.py
@@ -22,7 +22,7 @@ class S3StorageBackend(StorageBackend):
         super(S3StorageBackend, self).__init__(**kwargs)
 
         assert s3connection or (aws_key and aws_secret)
-        self._conn = s3connection or S3Connection(aws_key, aws_secret)
+        self._conn = s3connection or S3Connection(aws_key, aws_secret, validate_certs=True)
 
         assert bucket or url
         bucket_name = bucket or urlparse(url).netloc


### PR DESCRIPTION
JIRA: https://elevatelabs.atlassian.net/browse/ENG-5450

I'm investigating the issue with network requests via Zinc running over HTTP instead of HTTPS.

After digging through our codebases and TeamCity, I couldn't find a precise spot where we are setting a url with HTTP, and most importantly I couldn't find places where we request any of the buckets `com.wonder.content4`, `com.wonder.content2` or `com.wonder.moai_games`, since in our clients code and in TeamCity we set up as content bucket `com.wonder.content5` and as game bucket `com.wonder.moai_games2`.

However, one thing that I realized is that in Zinc we are using an old version of the AWS Python SDK that doesn't set up connections over HTTPS by default. [This page](https://aws.amazon.com/blogs/developer/configure-boto-to-validate-https-certificates/) suggests either upgrading the SDK or setting it up to always verify SSL certs.

So, I thought that one attempt at solving this problem might be to make sure that Zinc is always performing SSL certs validation when connecting to AWS.

I am not sure if we should just apply this change to the `S3Connection`s or also to the connection to the AWS region in `SimpleDBCatalogCoordinator`. In the latter class, I noticed that 3 years ago [we merged a PR](https://github.com/mindsnacks/Zinc/pull/30) that does the opposite thing, however the PR doesn't give much context on why that was necessary.

I'd like to get other people's thoughts on these findings and on the easiest way to test these changes safely.