### PR TITLE
Upgrade to boto3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,9 +56,6 @@ License
 
 Zinc is distributed under a BSD-style license.
 
-    Copyright (c) 2011-2013 MindSnacks (http://mindsnacks.com/)
-    
-    Copyright (c) 2014-Present Andy Mroczkowski
         
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 lockfile==0.9.1
 boto==2.49.0
+boto3==1.26.160
 toml
 requests
 jsonschema==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 lockfile==0.9.1
-boto==2.49.0
 boto3==1.26.160
 toml
 requests

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ install_requires = [
     # http://packages.python.org/distribute/setuptools.html#declaring-dependencies
     "toml==0.10.0",
     "lockfile==0.9.1",
-    "boto==2.49.0",
     "boto3==1.26.160",
     "atomicwrites==1.3.0",
     "redis==4.4.4",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.rst')).read()
 NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 
-version = '0.2.0'
+version = '0.2.1'
 
 install_requires = [
     # List your project dependencies here.

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ install_requires = [
     "toml==0.10.0",
     "lockfile==0.9.1",
     "boto==2.49.0",
+    "boto3==1.26.160",
     "atomicwrites==1.3.0",
     "redis==4.4.4",
     "jsonschema==1.3.0",

--- a/src/zinc/catalog.py
+++ b/src/zinc/catalog.py
@@ -284,7 +284,7 @@ class ZincCatalog(ZincAbstractCatalog):
         return None
 
     def _write(self, subpath: str, bytes: bytes, raw: bool = True, gzip: bool = True, max_age: Optional[int] = None):
-        log.debug(f"ZincCatalog: _write() called. (subpath: {subpath}, raw: {raw}, gzip: {gzip})")
+        log.debug(f'ZincCatalog: _write() called. (subpath: {subpath}, raw: {raw}, gzip: {gzip})')
         if raw:
             self._storage.puts(subpath, bytes, max_age=max_age)
         if gzip:
@@ -336,7 +336,7 @@ class ZincCatalog(ZincAbstractCatalog):
         return self._storage.get(subpath)
 
     def _write_file(self, sha, src_path, format=None):
-        log.debug(f"ZincCatalog: _write_file() called. (sha: {sha}, src_path: {src_path}, format: {format})")
+        log.debug(f'ZincCatalog: _write_file() called. (sha: {sha}, src_path: {src_path}, format: {format})')
         format = format or Formats.RAW  # default to RAW
         if format not in defaults['catalog_valid_formats']:
             raise Exception("Invalid format '%s'." % (format))
@@ -354,8 +354,8 @@ class ZincCatalog(ZincAbstractCatalog):
         return meta
 
     def _write_archive(self, bundle_name, version, src_path, flavor=None):
-        log.debug(f"ZincCatalog: _write_archive() called. (bundle_name: {bundle_name}, version: {version},"
-                  f" src_path: {src_path}, flavor: {flavor})")
+        log.debug(f'ZincCatalog: _write_archive() called. (bundle_name: {bundle_name}, version: {version},'
+                  f' src_path: {src_path}, flavor: {flavor})')
         subpath = self._ph.path_for_archive_for_bundle_version(bundle_name,
                                                                version,
                                                                flavor=flavor)

--- a/src/zinc/catalog.py
+++ b/src/zinc/catalog.py
@@ -284,6 +284,7 @@ class ZincCatalog(ZincAbstractCatalog):
         return None
 
     def _write(self, subpath: str, bytes: bytes, raw: bool = True, gzip: bool = True, max_age: Optional[int] = None):
+        log.info(f"ZincCatalog: _write() called with subpath == {subpath}, raw == {raw}, gzip == {gzip}")
         if raw:
             self._storage.puts(subpath, bytes, max_age=max_age)
         if gzip:
@@ -335,6 +336,7 @@ class ZincCatalog(ZincAbstractCatalog):
         return self._storage.get(subpath)
 
     def _write_file(self, sha, src_path, format=None):
+        log.info(f"ZincCatalog: _write_file() called with sha == {sha}, src_path == {src_path}, format == {format}")
         format = format or Formats.RAW  # default to RAW
         if format not in defaults['catalog_valid_formats']:
             raise Exception("Invalid format '%s'." % (format))
@@ -352,6 +354,8 @@ class ZincCatalog(ZincAbstractCatalog):
         return meta
 
     def _write_archive(self, bundle_name, version, src_path, flavor=None):
+        log.info(f"ZincCatalog: _write_archive() called with bundle_name == {bundle_name}, version == {version},"
+                 f" src_path == {src_path}, flavor == {flavor}")
         subpath = self._ph.path_for_archive_for_bundle_version(bundle_name,
                                                                version,
                                                                flavor=flavor)

--- a/src/zinc/catalog.py
+++ b/src/zinc/catalog.py
@@ -64,7 +64,7 @@ class ZincCatalogPathHelper(object):
         return self.path_for_manifest_for_bundle_version(
             manifest.bundle_name, manifest.version)
 
-    def path_for_file_with_sha(self, sha: str, ext: str = None, format=None) -> str:
+    def path_for_file_with_sha(self, sha: str, ext: Optional[str] = None, format=None) -> str:
 
         if ext is not None and format is not None:
             raise Exception("Should specify either `ext` or `format`, not both.")
@@ -77,14 +77,14 @@ class ZincCatalogPathHelper(object):
             file = file + '.' + ext
         return os.path.join(subdir, file)
 
-    def archive_name(self, bundle_name: str, version: int, flavor: str = None):
+    def archive_name(self, bundle_name: str, version: int, flavor: Optional[str] = None):
         if flavor is None:
             return "%s-%d.tar" % (bundle_name, version)
         else:
             return "%s-%d~%s.tar" % (bundle_name, version, flavor)
 
     def path_for_archive_for_bundle_version(
-            self, bundle_name: str, version: int, flavor: str = None):
+            self, bundle_name: str, version: int, flavor: Optional[str] = None):
         archive_filename = self.archive_name(bundle_name, version, flavor=flavor)
         archive_path = os.path.join(self.archives_dir, archive_filename)
         return archive_path
@@ -499,7 +499,7 @@ class ZincCatalog(ZincAbstractCatalog):
         subpath = self._ph.path_for_flavorspec_name(name)
         self._write(subpath, json_string.encode('utf8'), raw=True, gzip=False)
 
-    def update_flavorspec_from_path(self, src_path: str, name: str = None):
+    def update_flavorspec_from_path(self, src_path: str, name: Optional[str] = None):
         with open(src_path, 'r') as src_file:
             json_string = src_file.read()
         if name is None:

--- a/src/zinc/catalog.py
+++ b/src/zinc/catalog.py
@@ -284,7 +284,7 @@ class ZincCatalog(ZincAbstractCatalog):
         return None
 
     def _write(self, subpath: str, bytes: bytes, raw: bool = True, gzip: bool = True, max_age: Optional[int] = None):
-        log.info(f"ZincCatalog: _write() called with subpath == {subpath}, raw == {raw}, gzip == {gzip}")
+        log.debug(f"ZincCatalog: _write() called. (subpath: {subpath}, raw: {raw}, gzip: {gzip})")
         if raw:
             self._storage.puts(subpath, bytes, max_age=max_age)
         if gzip:
@@ -336,7 +336,7 @@ class ZincCatalog(ZincAbstractCatalog):
         return self._storage.get(subpath)
 
     def _write_file(self, sha, src_path, format=None):
-        log.info(f"ZincCatalog: _write_file() called with sha == {sha}, src_path == {src_path}, format == {format}")
+        log.debug(f"ZincCatalog: _write_file() called. (sha: {sha}, src_path: {src_path}, format: {format})")
         format = format or Formats.RAW  # default to RAW
         if format not in defaults['catalog_valid_formats']:
             raise Exception("Invalid format '%s'." % (format))
@@ -354,8 +354,8 @@ class ZincCatalog(ZincAbstractCatalog):
         return meta
 
     def _write_archive(self, bundle_name, version, src_path, flavor=None):
-        log.info(f"ZincCatalog: _write_archive() called with bundle_name == {bundle_name}, version == {version},"
-                 f" src_path == {src_path}, flavor == {flavor}")
+        log.debug(f"ZincCatalog: _write_archive() called. (bundle_name: {bundle_name}, version: {version},"
+                  f" src_path: {src_path}, flavor: {flavor})")
         subpath = self._ph.path_for_archive_for_bundle_version(bundle_name,
                                                                version,
                                                                flavor=flavor)

--- a/src/zinc/client.py
+++ b/src/zinc/client.py
@@ -8,6 +8,7 @@ from collections import namedtuple
 from urllib.parse import urlparse
 import toml
 import json
+from typing import Optional
 
 import zinc.helpers as helpers
 import zinc.utils as utils
@@ -212,7 +213,7 @@ class ResultSet(object):
 
 ################################################################################
 
-def catalog_list(catalog: ZincCatalog, distro: str = None, print_versions: bool = True, **kwargs):
+def catalog_list(catalog: ZincCatalog, distro: Optional[str] = None, print_versions: bool = True, **kwargs):
 
     index = catalog.get_index()
 
@@ -251,7 +252,8 @@ def catalog_list(catalog: ZincCatalog, distro: str = None, print_versions: bool 
     return ResultSet(results)
 
 
-def bundle_list(catalog: ZincCatalog, bundle_name: str, version_ish, print_sha: bool = False, flavor_name: str = None):
+def bundle_list(catalog: ZincCatalog, bundle_name: str, version_ish, print_sha: bool = False,
+                flavor_name: Optional[str] = None):
 
     version = _resolve_single_bundle_version(catalog, bundle_name, version_ish)
     manifest = catalog.manifest_for_bundle(bundle_name, version=version)

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -89,6 +89,7 @@ class Lock(object):
                     AttributeNames=[LOCK_TOKEN, LOCK_EXPIRES],
                     ConsistentRead=True
                 )
+                print(response)
                 lock_expires = None
                 lock_token = None
                 for attribute in response['Attributes']:

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -211,7 +211,7 @@ class SimpleDBCatalogCoordinator(CatalogCoordinator):
     def _ensure_domain_exists(self, client=None, sdb_domain=None):
         log.debug('SimpleDBCatalogCoordinator: Calling SimpleDB_client.list_domains() '
                   f"to check for the name '{sdb_domain}'")
-        response = client.list_domains(MaxNumberOfDomains=100)
+        response = client.list_domains()
         domain_names = None
         if 'DomainNames' in response:
             domain_names = response['DomainNames']

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -170,6 +170,11 @@ class Lock(object):
             self._sdb_client.delete_attributes(
                 DomainName=self._sdb_domain_name,
                 ItemName=self._key,
+                Attributes=[
+                    {
+                        'Name': LOCK_EXPIRES,
+                    },
+                ],
                 Expected={
                     'Name': LOCK_TOKEN,
                     'Value': self._token,

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -118,7 +118,7 @@ class Lock(object):
                             ],
                             Expected={
                                 'Name': LOCK_TOKEN,
-                                'Value': lock_token,
+                                'Value': lock_token or self._token,
                                 'Exists': True
                             }
                         )

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -39,7 +39,7 @@ class Lock(object):
         `lock_token`."""
 
         attrs = self._get_lock_attrs()
-        log.debug('Refreshing lock... %s' % (attrs))
+        log.info('Refreshing lock... %s' % (attrs))
 
         self._sdb_client.put_attributes(
             DomainName=self._sdb_domain_name,
@@ -123,6 +123,7 @@ class Lock(object):
                             }
                         )
                 if lock_token is None:
+                    log.info('Putting attributes "lock_token" and "lock_expiry"')
                     self._sdb_client.put_attributes(
                         DomainName=self._sdb_domain_name,
                         ItemName=self._key,
@@ -174,6 +175,7 @@ class Lock(object):
                 if 'Name' in attribute and 'Value' in attribute and attribute['Name'] == LOCK_TOKEN:
                     lock_token = attribute['Value']
         if lock_token == self._token:
+            log.info('Releasing lock (Deleting "lock_token" and "lock_expiry" attributes)')
             self._sdb_client.delete_attributes(
                 DomainName=self._sdb_domain_name,
                 ItemName=self._key,

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -175,19 +175,10 @@ class Lock(object):
                 if 'Name' in attribute and 'Value' in attribute and attribute['Name'] == LOCK_TOKEN:
                     lock_token = attribute['Value']
         if lock_token == self._token:
-            log.info('Releasing lock (Deleting "lock_token" and "lock_expiry" attributes)')
+            log.info(f'Releasing lock (Deleting all attributes for ItemName {self._key})')
             self._sdb_client.delete_attributes(
                 DomainName=self._sdb_domain_name,
                 ItemName=self._key,
-                Attributes=[
-                    {
-                        'Name': LOCK_TOKEN,
-                        'Value': self._token,
-                    },
-                    {
-                        'Name': LOCK_EXPIRES,
-                    },
-                ],
                 Expected={
                     'Name': LOCK_TOKEN,
                     'Value': self._token,

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -134,7 +134,8 @@ class Lock(object):
                             },
                             {
                                 'Name': LOCK_EXPIRES,
-                                'Value': f"{time.time() + self._expires}"
+                                'Value': f"{time.time() + self._expires}",
+                                'Replace': True
                             },
                         ],
                         Expected={

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -112,6 +112,7 @@ class Lock(object):
                                 'Exists': True
                             }
                         )
+                        lock_token = None
                 if lock_token is None:
                     log.info('Putting attributes "lock_token" and "lock_expiry"')
                     self._sdb_client.put_attributes(

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -89,12 +89,10 @@ class Lock(object):
                     AttributeNames=[LOCK_TOKEN, LOCK_EXPIRES],
                     ConsistentRead=True
                 )
-                print(response)
                 lock_expires = None
                 lock_token = None
                 if 'Attributes' in response:
                     for attribute in response['Attributes']:
-                        print(attribute)
                         if 'Name' in attribute and 'Value' in attribute:
                             if attribute['Name'] == LOCK_EXPIRES:
                                 lock_expires = attribute['Value']

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -232,4 +232,4 @@ class SimpleDBCatalogCoordinator(CatalogCoordinator):
     def valid_url(cls, url):
         urlcomps = urlparse(url)
         s = boto3.session.Session()
-        return urlcomps.scheme == 'sdb' and urlcomps.netloc in [r.name for r in s.get_available_regions('sdb')]
+        return urlcomps.scheme == 'sdb' and urlcomps.netloc in s.get_available_regions('sdb')

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -106,19 +106,9 @@ class Lock(object):
                         self._sdb_client.delete_attributes(
                             DomainName=self._sdb_domain_name,
                             ItemName=self._key,
-                            Attributes=[
-                                {
-                                    'Name': LOCK_EXPIRES,
-                                    'Value': lock_expires or '',
-                                 },
-                                {
-                                    'Name': LOCK_TOKEN,
-                                    'Value': lock_token or '',
-                                },
-                            ],
                             Expected={
                                 'Name': LOCK_TOKEN,
-                                'Value': lock_token or self._token,
+                                'Value': lock_token,
                                 'Exists': True
                             }
                         )

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -92,11 +92,14 @@ class Lock(object):
                 print(response)
                 lock_expires = None
                 lock_token = None
-                for attribute in response['Attributes']:
-                    if attribute['Name'] == LOCK_EXPIRES:
-                        lock_expires = attribute['Value']
-                    elif attribute['Name'] == LOCK_TOKEN:
-                        lock_token = attribute['Value']
+                if 'Attributes' in response:
+                    for attribute in response['Attributes']:
+                        print(attribute)
+                        if 'Name' in attribute and 'Value' in attribute:
+                            if attribute['Name'] == LOCK_EXPIRES:
+                                lock_expires = attribute['Value']
+                            elif attribute['Name'] == LOCK_TOKEN:
+                                lock_token = attribute['Value']
                 if self._expires != 0:
                     if lock_expires is None or time.time() > float(lock_expires):
                         log.info('Clearing expired lock...')
@@ -166,9 +169,10 @@ class Lock(object):
             ConsistentRead=True
         )
         lock_token = None
-        for attribute in response['Attributes']:
-            if attribute['Name'] == LOCK_TOKEN:
-                lock_token = attribute['Value']
+        if 'Attributes' in response:
+            for attribute in response['Attributes']:
+                if 'Name' in attribute and 'Value' in attribute and attribute['Name'] == LOCK_TOKEN:
+                    lock_token = attribute['Value']
         if lock_token == self._token:
             self._sdb_client.delete_attributes(
                 DomainName=self._sdb_domain_name,

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -226,8 +226,24 @@ class SimpleDBCatalogCoordinator(CatalogCoordinator):
         )
         client = session.client('sdb')
 
-        client.create_domain(DomainName=sdb_domain)
+        # client.create_domain(DomainName=sdb_domain)
+        self._ensure_domain_exists(client=client, sdb_domain=sdb_domain)
 
+    def _ensure_domain_exists(self, client=None, sdb_domain=None):
+        log.info("Calling SimpleDB_client.list_domains() to check for the name '%s'", sdb_domain)
+        response = client.list_domains(MaxNumberOfDomains=100)
+        domain_names = None
+        if 'DomainNames' in response:
+            domain_names = response['DomainNames']
+            log.info("SimpleDB_client.list_domains()['DomainNames'] == [%s]", ", ".join(domain_names))
+        else:
+            log.info("SimpleDB_client.list_domains() returned response without 'DomainNames' key")
+
+        if domain_names is None or sdb_domain not in domain_names:
+            log.info("Creating new domain with name '%s'", sdb_domain)
+            client.create_domain(DomainName=sdb_domain)
+        else:
+            log.info(f"Domain with name '{sdb_domain}' already exists")
         self._client = client
         self._domain_name = sdb_domain
 

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -170,11 +170,6 @@ class Lock(object):
             self._sdb_client.delete_attributes(
                 DomainName=self._sdb_domain_name,
                 ItemName=self._key,
-                Attributes=[
-                    {
-                        'Name': LOCK_EXPIRES,
-                    },
-                ],
                 Expected={
                     'Name': LOCK_TOKEN,
                     'Value': self._token,

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -101,7 +101,7 @@ class Lock(object):
                             elif attribute['Name'] == LOCK_TOKEN:
                                 lock_token = attribute['Value']
                 if self._expires != 0:
-                    if lock_expires is None or time.time() > float(lock_expires):
+                    if lock_token is not None and (lock_expires is None or time.time() > float(lock_expires)):
                         log.info('Clearing expired lock...')
                         self._sdb_client.delete_attributes(
                             DomainName=self._sdb_domain_name,

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -132,7 +132,7 @@ class Lock(object):
                                 'Value': self._token
                             },
                             {
-                                'Nane': LOCK_EXPIRES,
+                                'Name': LOCK_EXPIRES,
                                 'Value': f"{time.time() + self._expires}"
                             },
                         ],

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -123,7 +123,7 @@ class Lock(object):
                             },
                             {
                                 'Name': LOCK_EXPIRES,
-                                'Value': f"{time.time() + self._expires}",
+                                'Value': f'{time.time() + self._expires}',
                             },
                         ],
                         Expected={
@@ -140,7 +140,7 @@ class Lock(object):
                     log.debug('Sleeping')
                     time.sleep(1)
                 else:
-                    raise LockException("Failed to acquire lock within timeout.")
+                    raise LockException('Failed to acquire lock within timeout.')
 
             except botocore.exceptions.ClientError as error:
                 error_code = error.response['Error']['Code']
@@ -209,16 +209,16 @@ class SimpleDBCatalogCoordinator(CatalogCoordinator):
         self._ensure_domain_exists(client=client, sdb_domain=sdb_domain)
 
     def _ensure_domain_exists(self, client=None, sdb_domain=None):
-        log.debug(f"SimpleDBCatalogCoordinator: Calling SimpleDB_client.list_domains() "
+        log.debug('SimpleDBCatalogCoordinator: Calling SimpleDB_client.list_domains() '
                   f"to check for the name '{sdb_domain}'")
         response = client.list_domains(MaxNumberOfDomains=100)
         domain_names = None
         if 'DomainNames' in response:
             domain_names = response['DomainNames']
-            log.debug("SimpleDBCatalogCoordinator: SimpleDB_client.list_domains() returned response where "
+            log.debug('SimpleDBCatalogCoordinator: SimpleDB_client.list_domains() returned response where '
                       f"the key 'DomainNames' has the value [{', '.join(domain_names) }]")
         else:
-            log.debug("SimpleDBCatalogCoordinator: SimpleDB_client.list_domains() returned "
+            log.debug('SimpleDBCatalogCoordinator: SimpleDB_client.list_domains() returned '
                       "response without 'DomainNames' key")
 
         if domain_names is None or sdb_domain not in domain_names:

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -206,7 +206,6 @@ class SimpleDBCatalogCoordinator(CatalogCoordinator):
         )
         client = session.client('sdb')
 
-        # client.create_domain(DomainName=sdb_domain)
         self._ensure_domain_exists(client=client, sdb_domain=sdb_domain)
 
     def _ensure_domain_exists(self, client=None, sdb_domain=None):

--- a/src/zinc/coordinators/aws.py
+++ b/src/zinc/coordinators/aws.py
@@ -135,7 +135,6 @@ class Lock(object):
                             {
                                 'Name': LOCK_EXPIRES,
                                 'Value': f"{time.time() + self._expires}",
-                                'Replace': True
                             },
                         ],
                         Expected={
@@ -187,7 +186,6 @@ class Lock(object):
                     },
                     {
                         'Name': LOCK_EXPIRES,
-                        'Value': '',
                     },
                 ],
                 Expected={

--- a/src/zinc/defaults.py
+++ b/src/zinc/defaults.py
@@ -19,9 +19,9 @@ Configurations:
 """
 
 from .formats import Formats
+from typing import Any, Dict
 
-defaults = dict()
-
+defaults: Dict[str, Any] = dict()
 
 defaults['zinc_format'] = '1'
 defaults['catalog_index_name'] = 'catalog.json'

--- a/src/zinc/defaults.py
+++ b/src/zinc/defaults.py
@@ -16,7 +16,6 @@ Configurations:
 :catalog_valid_formats: A list of valid formats for objects in the catalog.
 :catalog_lock_timeout: Timeout for acquiring a lock on the catalog via a coordinator.
 :catalog_prev_distro_prefix: The prefix to use when writing the previous distro.
-:storage_aws_read_retry_count: Number of times to retry an operation using an 'S3StorageBackend'.
 """
 
 from .formats import Formats
@@ -33,4 +32,3 @@ defaults['catalog_preferred_formats'] = [Formats.GZ, Formats.RAW]
 defaults['catalog_valid_formats'] = defaults['catalog_preferred_formats']
 defaults['catalog_lock_timeout'] = 60
 defaults['catalog_prev_distro_prefix'] = '_'
-defaults['storage_aws_read_retry_count'] = 3

--- a/src/zinc/helpers.py
+++ b/src/zinc/helpers.py
@@ -13,7 +13,7 @@ def make_bundle_id(catalog_id: str, bundle_name: str) -> str:
     return '%s.%s' % (catalog_id, bundle_name)
 
 
-def make_bundle_descriptor(bundle_id: str, version: int, flavor: str = None) -> str:
+def make_bundle_descriptor(bundle_id: str, version: int, flavor: Optional[str] = None) -> str:
     assert bundle_id
     assert version
     descriptor = '%s-%d' % (bundle_id, version)

--- a/src/zinc/storages/aws.py
+++ b/src/zinc/storages/aws.py
@@ -82,9 +82,14 @@ class S3StorageBackend(StorageBackend):
         return meta
 
     def put(self, subpath, fileobj, max_age=None, **kwargs):
-        log.info(f"S3StorageBackend: put() called with subpath == '{subpath}'")
+        log.info(f"S3StorageBackend: put() called with subpath == '{subpath}', max_age == {max_age}")
+        extra_args = None
+        if max_age is not None:
+            extra_args = {
+                'CacheControl': f'max-age={max_age}'
+            }
         keyname = self._get_keyname(subpath)
-        self._bucket.upload_fileobj(fileobj, keyname)
+        self._bucket.upload_fileobj(fileobj, keyname, ExtraArgs=extra_args)
 
     def list(self, prefix=None):
         contents = []

--- a/src/zinc/storages/aws.py
+++ b/src/zinc/storages/aws.py
@@ -82,7 +82,7 @@ class S3StorageBackend(StorageBackend):
         return meta
 
     def put(self, subpath, fileobj, max_age=None, **kwargs):
-        log.info(f"S3StorageBackend: put() called with subpath == '{subpath}', max_age == {max_age}")
+        log.debug(f"S3StorageBackend: put() called. (subpath: '{subpath}', max_age: {max_age})")
         extra_args = None
         if max_age is not None:
             extra_args = {

--- a/src/zinc/storages/aws.py
+++ b/src/zinc/storages/aws.py
@@ -62,7 +62,7 @@ class S3StorageBackend(StorageBackend):
 
     def get(self, subpath):
         keyname = self._get_keyname(subpath)
-        t = TemporaryFile(mode="w+b")
+        t = TemporaryFile(mode='w+b')
         self._bucket.download_fileobj(keyname, t)
         if t.tell() == 0:
             return None
@@ -95,7 +95,7 @@ class S3StorageBackend(StorageBackend):
         contents = []
         subpath = self._get_keyname(prefix)
         for object_summary in self._bucket.objects.filter(prefix=subpath):
-            if object_summary.key.endswith("/"):
+            if object_summary.key.endswith('/'):
                 # skip "directory" keys
                 continue
             rel_path = object_summary.key[len(subpath) + 1:]

--- a/src/zinc/storages/aws.py
+++ b/src/zinc/storages/aws.py
@@ -4,12 +4,9 @@ from copy import copy
 from urllib.parse import urlparse
 import logging
 
-from boto.s3.key import Key
-from boto.s3.connection import S3Connection
-import http  # for IncompleteRead exception
+import boto3
 
 from . import StorageBackend
-from zinc.defaults import defaults
 
 log = logging.getLogger(__name__)
 
@@ -25,9 +22,27 @@ class S3StorageBackend(StorageBackend):
 
         assert bucket or url
         bucket_name = bucket or urlparse(url).netloc
-        self._conn = S3Connection(aws_key, aws_secret, is_secure=False, validate_certs=False)
-        self._bucket = self._conn.get_bucket(bucket_name)
+        session = boto3.session.Session(aws_access_key_id=aws_key, aws_secret_access_key=aws_secret)
+        connection = session.resource('s3')
+        self._bucket = self._get_bucket(bucket_name, connection)
         self._prefix = prefix
+
+    def _get_bucket(self, bucket_name, connection):
+        import botocore.exceptions
+        bucket = connection.Bucket(bucket_name)
+        exists = True
+        try:
+            connection.meta.client.head_bucket(Bucket=bucket_name)
+        except botocore.exceptions.ClientError as error:
+            error_code = error.response['Error']['Code']
+            if error_code == '404':
+                exists = False
+            else:
+                raise error
+        if exists:
+            return bucket
+        else:
+            return None
 
     @classmethod
     def valid_url(cls, url):
@@ -46,48 +61,39 @@ class S3StorageBackend(StorageBackend):
             return subpath
 
     def get(self, subpath):
-        key = self._bucket.get_key(self._get_keyname(subpath))
-        if key is not None:
-            t = TemporaryFile()
-            retry_count = 0
-            max_retry_count = defaults['storage_aws_read_retry_count']
-            while retry_count < max_retry_count:
-                try:
-                    retry_count = retry_count + 1
-                    t.write(key.read())
-                    t.seek(0)
-                    return t
-                except http.client.IncompleteRead as e:
-                    log.warn('Caught IncompleteRead, retrying (%d/%d)' % (retry_count, max_retry_count))
-                    log.warn('%s' % (e.message))
-
-        return None
+        keyname = self._get_keyname(subpath)
+        t = TemporaryFile(mode="w+b")
+        self._bucket.download_fileobj(keyname, t)
+        if t.tell() == 0:
+            return None
+        t.seek(0)
+        return t
 
     def get_meta(self, subpath):
-        key = self._bucket.lookup(self._get_keyname(subpath))
-        if key is None:
+
+        keyname = self._get_keyname(subpath)
+        object_sumary_iterator = self._bucket.objects.filter(Prefix=keyname, MaxKeys=1)
+        if len(object_sumary_iterator) == 0:
             return None
+        object_summary = object_sumary_iterator[0]
         meta = dict()
-        meta['size'] = key.size
+        meta['size'] = object_summary.size
         return meta
 
     def put(self, subpath, fileobj, max_age=None, **kwargs):
-        k = Key(self._bucket)
-        k.key = self._get_keyname(subpath)
-        if max_age is not None:
-            k.set_metadata('Cache-Control', 'max-age=%d' % (max_age))
-        k.set_contents_from_file(fileobj)
+        keyname = self._get_keyname(subpath)
+        self._bucket.upload_fileobj(fileobj, keyname)
 
     def list(self, prefix=None):
         contents = []
         subpath = self._get_keyname(prefix)
-        for k in self._bucket.list(prefix=subpath):
-            if k.name.endswith("/"):
+        for object_summary in self._bucket.objects.filter(prefix=subpath):
+            if object_summary.key.endswith("/"):
                 # skip "directory" keys
                 continue
-            rel_path = k.name[len(subpath) + 1:]
+            rel_path = object_summary.key[len(subpath) + 1:]
             contents.append(rel_path)
         return contents
 
     def delete(self, subpath):
-        self._bucket.delete_key(self._get_keyname(subpath))
+        self._bucket.objects.delete([self._get_keyname(subpath)])

--- a/src/zinc/storages/aws.py
+++ b/src/zinc/storages/aws.py
@@ -72,10 +72,11 @@ class S3StorageBackend(StorageBackend):
     def get_meta(self, subpath):
 
         keyname = self._get_keyname(subpath)
-        object_sumary_iterator = self._bucket.objects.filter(Prefix=keyname, MaxKeys=1)
-        if len(object_sumary_iterator) == 0:
+        object_summary_iterator = self._bucket.objects.filter(Prefix=keyname, MaxKeys=1)
+        object_summaries = list(object_summary_iterator)
+        if len(object_summaries) == 0:
             return None
-        object_summary = object_sumary_iterator[0]
+        object_summary = object_summaries[0]
         meta = dict()
         meta['size'] = object_summary.size
         return meta

--- a/src/zinc/storages/aws.py
+++ b/src/zinc/storages/aws.py
@@ -82,6 +82,7 @@ class S3StorageBackend(StorageBackend):
         return meta
 
     def put(self, subpath, fileobj, max_age=None, **kwargs):
+        log.info(f"S3StorageBackend: put() called with subpath == '{subpath}'")
         keyname = self._get_keyname(subpath)
         self._bucket.upload_fileobj(fileobj, keyname)
 

--- a/src/zinc/utils.py
+++ b/src/zinc/utils.py
@@ -19,7 +19,7 @@ from io import BytesIO
 from types import GeneratorType
 from itertools import tee
 
-Tee = tee([], 1)[0].__class__
+Tee: type = tee([], 1)[0].__class__
 
 
 class EnumMC(type):
@@ -65,7 +65,7 @@ def canonical_path(path: str) -> str:
     return path
 
 
-def makedirs(path: str) -> str:
+def makedirs(path: str):
     """Convenience method that ignores errors if directory already exists."""
     try:
         os.makedirs(path)


### PR DESCRIPTION
Replaces the `boto` library with `boto3`, which uses SSL by default.  🆙

I've tested these changes with a few deploys:
- Created a new catalog and [deployed game assets](https://github.com/mindsnacks/wonder_content/actions/runs/5417625206) to it, then verified that I could download game assets from it normally.  ✔️
- Changed a game asset and [deployed again](https://github.com/mindsnacks/wonder_content/actions/runs/5417699731), then verified that the next time I opened the game, the altered asset was used.  ✔️
- Once I was sure that `max-age` was working the same way it used to with regular `boto`, did a [debug content deploy](https://github.com/mindsnacks/wonder_content/actions/runs/5417747008) on our regular catalog and verified that content assets were still downloading in debug builds. ✔️
- Did release [game](https://github.com/mindsnacks/wonder_content/actions/runs/5418157103) and [content](https://github.com/mindsnacks/wonder_content/actions/runs/5418236897) deploys and verified that the `catalog.json` was updated properly.  ✔️ 


